### PR TITLE
CAL-20 Add capability to extract KLV metadata from MPEG transport streams by the STANAG 4609 standard

### DIFF
--- a/catalog/nsili/catalog-nsili-source/pom.xml
+++ b/catalog/nsili/catalog-nsili-source/pom.xml
@@ -4,7 +4,7 @@
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or any later version. 
+ * version 3 of the License, or any later version.
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
@@ -139,24 +139,6 @@
             <groupId>ddf.catalog.core</groupId>
             <artifactId>filter-proxy</artifactId>
             <version>${ddf.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.9.5</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.8</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <version>1.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/catalog/nsili/catalog-nsili-transformer/pom.xml
+++ b/catalog/nsili/catalog-nsili-transformer/pom.xml
@@ -56,11 +56,6 @@
             <artifactId>jts</artifactId>
             <version>1.12</version>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/libs/pom.xml
+++ b/libs/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>alliance</artifactId>
+        <groupId>org.codice</groupId>
+        <version>0.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.codice.alliance</groupId>
+    <artifactId>libs</artifactId>
+    <packaging>pom</packaging>
+    <name>Alliance :: Libs</name>
+
+    <modules>
+        <module>stanag4609</module>
+    </modules>
+
+</project>

--- a/libs/stanag4609/pom.xml
+++ b/libs/stanag4609/pom.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.codice.alliance</groupId>
+        <artifactId>libs</artifactId>
+        <version>0.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>stanag4609</artifactId>
+    <name>Alliance :: STANAG 4609</name>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jcodec</groupId>
+            <artifactId>jcodec</artifactId>
+            <version>0.2.0_1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf</groupId>
+            <artifactId>klv</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf</groupId>
+            <artifactId>mpeg-transport-stream</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commons-io.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Embed-Dependency>
+                            jcodec
+                        </Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.97</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.87</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.90</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.92</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/libs/stanag4609/src/main/java/org/codice/alliance/libs/stanag4609/AbstractMetadataPacket.java
+++ b/libs/stanag4609/src/main/java/org/codice/alliance/libs/stanag4609/AbstractMetadataPacket.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.libs.stanag4609;
+
+import java.util.Arrays;
+
+import org.codice.ddf.libs.klv.KlvContext;
+import org.codice.ddf.libs.klv.KlvDecoder;
+import org.codice.ddf.libs.klv.KlvDecodingException;
+import org.codice.ddf.libs.klv.data.numerical.KlvUnsignedShort;
+import org.codice.ddf.libs.klv.data.set.KlvLocalSet;
+import org.jcodec.containers.mps.MPSDemuxer.PESPacket;
+
+abstract class AbstractMetadataPacket {
+    protected final byte[] pesPacketBytes;
+
+    protected final PESPacket pesHeader;
+
+    protected final KlvDecoder decoder;
+
+    protected AbstractMetadataPacket(final byte[] pesPacketBytes, final PESPacket pesHeader,
+            final KlvDecoder decoder) {
+        this.pesPacketBytes = pesPacketBytes;
+        this.pesHeader = pesHeader;
+        this.decoder = decoder;
+    }
+
+    private boolean validateChecksum(final KlvContext klvContext, final byte[] klvBytes)
+            throws KlvDecodingException {
+        if (!klvContext.hasDataElement(Stanag4609TransportStreamParser.UAS_DATALINK_LOCAL_SET)) {
+            throw new KlvDecodingException("KLV did not contain the UAS Datalink Local Set");
+        }
+
+        final KlvContext localSetContext = ((KlvLocalSet) klvContext.getDataElementByName(
+                Stanag4609TransportStreamParser.UAS_DATALINK_LOCAL_SET)).getValue();
+
+        if (localSetContext.hasDataElement(Stanag4609TransportStreamParser.CHECKSUM)) {
+            final int packetChecksum = ((KlvUnsignedShort) localSetContext.getDataElementByName(
+                    Stanag4609TransportStreamParser.CHECKSUM)).getValue();
+
+            short calculatedChecksum = 0;
+            // Checksum is calculated by a 16-bit sum from the beginning of the KLV set to the 1-byte
+            // checksum length (the checksum value is 2 bytes, which is why we subtract 2).
+            for (int i = 0; i < klvBytes.length - 2; ++i) {
+                calculatedChecksum += (klvBytes[i] & 0xFF) << (8 * ((i + 1) % 2));
+            }
+
+            return (calculatedChecksum & 0xFFFF) == packetChecksum;
+        }
+
+        throw new KlvDecodingException(
+                "Decoded KLV packet didn't contain checksum (which is required).");
+    }
+
+    protected final byte[] getPESPacketPayload(final int packetLength,
+            final int expectedHeaderLength) {
+        final int payloadEnd = Math.min(pesPacketBytes.length, expectedHeaderLength + packetLength);
+        return Arrays.copyOfRange(pesPacketBytes, expectedHeaderLength, payloadEnd);
+    }
+
+    protected abstract byte[] getKLVBytes();
+
+    final DecodedKLVMetadataPacket decodeKLV() throws KlvDecodingException {
+        final byte[] klvBytes = getKLVBytes();
+
+        if (klvBytes != null && klvBytes.length > 0) {
+            final KlvContext decodedKLV = decoder.decode(klvBytes);
+
+            if (validateChecksum(decodedKLV, klvBytes)) {
+                return new DecodedKLVMetadataPacket(pesHeader.pts, decodedKLV);
+            } else {
+                throw new KlvDecodingException("KLV packet checksum does not match.");
+            }
+        }
+
+        return null;
+    }
+}

--- a/libs/stanag4609/src/main/java/org/codice/alliance/libs/stanag4609/AsynchronousMetadataPacket.java
+++ b/libs/stanag4609/src/main/java/org/codice/alliance/libs/stanag4609/AsynchronousMetadataPacket.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.libs.stanag4609;
+
+import org.codice.ddf.libs.klv.KlvDecoder;
+import org.jcodec.containers.mps.MPSDemuxer.PESPacket;
+
+class AsynchronousMetadataPacket extends AbstractMetadataPacket {
+    private static final int ASYNCHRONOUS_PES_PACKET_HEADER_LENGTH = 9;
+
+    AsynchronousMetadataPacket(final byte[] pesPacketBytes, final PESPacket pesHeader,
+            final KlvDecoder decoder) {
+        super(pesPacketBytes, pesHeader, decoder);
+    }
+
+    @Override
+    protected byte[] getKLVBytes() {
+        // For asynchronous metadata streams, the header is supposed to be 9 bytes long. The header's
+        // length field gives the number of bytes in the packet following it, so we need to skip
+        // the 3 header bytes after the length field to get the true length of the payload.
+        return getPESPacketPayload(pesHeader.length - 3, ASYNCHRONOUS_PES_PACKET_HEADER_LENGTH);
+    }
+}

--- a/libs/stanag4609/src/main/java/org/codice/alliance/libs/stanag4609/DecodedKLVMetadataPacket.java
+++ b/libs/stanag4609/src/main/java/org/codice/alliance/libs/stanag4609/DecodedKLVMetadataPacket.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.libs.stanag4609;
+
+import org.codice.ddf.libs.klv.KlvContext;
+
+/**
+ * Represents a decoded KLV metadata packet. The presentation timestamp is non-negative only if this
+ * object represents a synchronous KLV metadata packet.
+ */
+public class DecodedKLVMetadataPacket {
+    private final long presentationTimestamp;
+
+    private final KlvContext decodedKLV;
+
+    DecodedKLVMetadataPacket(final long presentationTimestamp, final KlvContext decodedKLV) {
+        this.presentationTimestamp = presentationTimestamp;
+        this.decodedKLV = decodedKLV;
+    }
+
+    public long getPresentationTimestamp() {
+        return presentationTimestamp;
+    }
+
+    public KlvContext getDecodedKLV() {
+        return decodedKLV;
+    }
+}

--- a/libs/stanag4609/src/main/java/org/codice/alliance/libs/stanag4609/Stanag4609TransportStreamParser.java
+++ b/libs/stanag4609/src/main/java/org/codice/alliance/libs/stanag4609/Stanag4609TransportStreamParser.java
@@ -1,0 +1,379 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.libs.stanag4609;
+
+import static org.codice.ddf.libs.klv.data.Klv.KeyLength;
+import static org.codice.ddf.libs.klv.data.Klv.LengthEncoding;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import org.codice.ddf.libs.klv.KlvContext;
+import org.codice.ddf.libs.klv.KlvDecoder;
+import org.codice.ddf.libs.klv.KlvDecodingException;
+import org.codice.ddf.libs.klv.data.numerical.KlvInt;
+import org.codice.ddf.libs.klv.data.numerical.KlvIntegerEncodedFloatingPoint;
+import org.codice.ddf.libs.klv.data.numerical.KlvLong;
+import org.codice.ddf.libs.klv.data.numerical.KlvShort;
+import org.codice.ddf.libs.klv.data.numerical.KlvUnsignedByte;
+import org.codice.ddf.libs.klv.data.numerical.KlvUnsignedShort;
+import org.codice.ddf.libs.klv.data.set.KlvLocalSet;
+import org.codice.ddf.libs.klv.data.text.KlvString;
+import org.codice.ddf.libs.mpeg.transport.MpegTransportStreamMetadataExtractor;
+import org.jcodec.containers.mps.MPSDemuxer.PESPacket;
+import org.jcodec.containers.mps.MPSUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.io.ByteSource;
+
+/**
+ * Parses an MPEG-2 transport stream according to the STANAG 4609 standard. It supports a subset of
+ * the UAS Datalink Local Set KLV (MISB ST 0601).
+ */
+public class Stanag4609TransportStreamParser {
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(Stanag4609TransportStreamParser.class);
+
+    private static final int MAX_UNSIGNED_SHORT = (1 << 16) - 1;
+
+    private static final long MAX_UNSIGNED_INT = (1L << 32) - 1;
+
+    private static final int METADATA_STREAM_ID = 0xFC;
+
+    private static final int PRIVATE_STREAM_ID = 0xBD;
+
+    public static final KlvContext UAS_DATALINK_LOCAL_SET_CONTEXT =
+            new KlvContext(KeyLength.SixteenBytes, LengthEncoding.BER);
+
+    public static final String UAS_DATALINK_LOCAL_SET = "UAS Datalink Local Set";
+
+    public static final String CHECKSUM = "checksum";
+
+    public static final String TIMESTAMP = "timestamp";
+
+    public static final String MISSION_ID = "mission id";
+
+    public static final String PLATFORM_TAIL_NUMBER = "platform tail number";
+
+    public static final String PLATFORM_DESIGNATION = "platform designation";
+
+    public static final String IMAGE_SOURCE_SENSOR = "image source sensor";
+
+    public static final String IMAGE_COORDINATE_SYSTEM = "image coordinate system";
+
+    public static final String SENSOR_LATITUDE = "sensor latitude";
+
+    public static final String SENSOR_LONGITUDE = "sensor longitude";
+
+    public static final String SENSOR_TRUE_ALTITUDE = "sensor true altitude";
+
+    public static final String SLANT_RANGE = "slant range";
+
+    public static final String TARGET_WIDTH = "target width";
+
+    public static final String FRAME_CENTER_LATITUDE = "frame center latitude";
+
+    public static final String FRAME_CENTER_LONGITUDE = "frame center longitude";
+
+    public static final String FRAME_CENTER_ELEVATION = "frame center elevation";
+
+    public static final String OFFSET_CORNER_LATITUDE_1 = "offset corner latitude 1";
+
+    public static final String OFFSET_CORNER_LONGITUDE_1 = "offset corner longitude 1";
+
+    public static final String OFFSET_CORNER_LATITUDE_2 = "offset corner latitude 2";
+
+    public static final String OFFSET_CORNER_LONGITUDE_2 = "offset corner longitude 2";
+
+    public static final String OFFSET_CORNER_LATITUDE_3 = "offset corner latitude 3";
+
+    public static final String OFFSET_CORNER_LONGITUDE_3 = "offset corner longitude 3";
+
+    public static final String OFFSET_CORNER_LATITUDE_4 = "offset corner latitude 4";
+
+    public static final String OFFSET_CORNER_LONGITUDE_4 = "offset corner longitude 4";
+
+    public static final String TARGET_LOCATION_LATITUDE = "target location latitude";
+
+    public static final String TARGET_LOCATION_LONGITUDE = "target location longitude";
+
+    public static final String TARGET_LOCATION_ELEVATION = "target location elevation";
+
+    public static final String GROUND_RANGE = "ground range";
+
+    public static final String PLATFORM_CALL_SIGN = "platform call sign";
+
+    public static final String EVENT_START_TIME = "event start time";
+
+    public static final String OPERATIONAL_MODE = "operational mode";
+
+    public static final String CORNER_LATITUDE_1 = "corner latitude 1";
+
+    public static final String CORNER_LONGITUDE_1 = "corner longitude 1";
+
+    public static final String CORNER_LATITUDE_2 = "corner latitude 2";
+
+    public static final String CORNER_LONGITUDE_2 = "corner longitude 2";
+
+    public static final String CORNER_LATITUDE_3 = "corner latitude 3";
+
+    public static final String CORNER_LONGITUDE_3 = "corner longitude 3";
+
+    public static final String CORNER_LATITUDE_4 = "corner latitude 4";
+
+    public static final String CORNER_LONGITUDE_4 = "corner longitude 4";
+
+    public static final String SECURITY_LOCAL_METADATA_SET = "security local metadata set";
+
+    public static final String SECURITY_CLASSIFICATION = "security classification";
+
+    public static final String CLASSIFYING_COUNTRY_CODING_METHOD = "country coding method";
+
+    public static final String CLASSIFYING_COUNTRY = "classifying country";
+
+    public static final String OBJECT_COUNTRY_CODING_METHOD = "object country coding method";
+
+    public static final String OBJECT_COUNTRY_CODES = "object country codes";
+
+    static {
+        final KlvContext localSetContext = new KlvContext(KeyLength.OneByte, LengthEncoding.BER);
+        final KlvLocalSet outerSet = new KlvLocalSet(new byte[] {0x06, 0x0E, 0x2B, 0x34, 0x02, 0x0B,
+                0x01, 0x01, 0x0E, 0x01, 0x03, 0x01, 0x01, 0x00, 0x00, 0x00},
+                UAS_DATALINK_LOCAL_SET,
+                localSetContext);
+
+        localSetContext.addDataElement(new KlvUnsignedShort(new byte[] {1}, CHECKSUM));
+        localSetContext.addDataElement(new KlvLong(new byte[] {2}, TIMESTAMP));
+        localSetContext.addDataElement(new KlvString(new byte[] {3}, MISSION_ID));
+        localSetContext.addDataElement(new KlvString(new byte[] {4}, PLATFORM_TAIL_NUMBER));
+        localSetContext.addDataElement(new KlvString(new byte[] {10}, PLATFORM_DESIGNATION));
+        localSetContext.addDataElement(new KlvString(new byte[] {11}, IMAGE_SOURCE_SENSOR));
+        localSetContext.addDataElement(new KlvString(new byte[] {12}, IMAGE_COORDINATE_SYSTEM));
+
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvInt(new byte[] {
+                13}, SENSOR_LATITUDE), Integer.MIN_VALUE + 1, Integer.MAX_VALUE, -90, 90));
+
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvInt(new byte[] {
+                14}, SENSOR_LONGITUDE), Integer.MIN_VALUE + 1, Integer.MAX_VALUE, -180, 180));
+
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvUnsignedShort(new byte[] {
+                15}, SENSOR_TRUE_ALTITUDE), 0, MAX_UNSIGNED_SHORT, -900, 19000));
+
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvLong(new byte[] {
+                21}, SLANT_RANGE), 0, MAX_UNSIGNED_INT, 0, 5000000));
+
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvUnsignedShort(new byte[] {
+                22}, TARGET_WIDTH), 0, MAX_UNSIGNED_SHORT, 0, 10000));
+
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvInt(new byte[] {
+                23}, FRAME_CENTER_LATITUDE), Integer.MIN_VALUE + 1, Integer.MAX_VALUE, -90, 90));
+
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvInt(new byte[] {
+                24}, FRAME_CENTER_LONGITUDE), Integer.MIN_VALUE + 1, Integer.MAX_VALUE, -180, 180));
+
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvUnsignedShort(new byte[] {
+                25}, FRAME_CENTER_ELEVATION), 0, MAX_UNSIGNED_SHORT, -900, 19000));
+
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvShort(new byte[] {
+                26}, OFFSET_CORNER_LATITUDE_1),
+                Short.MIN_VALUE + 1,
+                Short.MAX_VALUE,
+                -0.075,
+                0.075));
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvShort(new byte[] {
+                27}, OFFSET_CORNER_LONGITUDE_1),
+                Short.MIN_VALUE + 1,
+                Short.MAX_VALUE,
+                -0.075,
+                0.075));
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvShort(new byte[] {
+                28}, OFFSET_CORNER_LATITUDE_2),
+                Short.MIN_VALUE + 1,
+                Short.MAX_VALUE,
+                -0.075,
+                0.075));
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvShort(new byte[] {
+                29}, OFFSET_CORNER_LONGITUDE_2),
+                Short.MIN_VALUE + 1,
+                Short.MAX_VALUE,
+                -0.075,
+                0.075));
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvShort(new byte[] {
+                30}, OFFSET_CORNER_LATITUDE_3),
+                Short.MIN_VALUE + 1,
+                Short.MAX_VALUE,
+                -0.075,
+                0.075));
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvShort(new byte[] {
+                31}, OFFSET_CORNER_LONGITUDE_3),
+                Short.MIN_VALUE + 1,
+                Short.MAX_VALUE,
+                -0.075,
+                0.075));
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvShort(new byte[] {
+                32}, OFFSET_CORNER_LATITUDE_4),
+                Short.MIN_VALUE + 1,
+                Short.MAX_VALUE,
+                -0.075,
+                0.075));
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvShort(new byte[] {
+                33}, OFFSET_CORNER_LONGITUDE_4),
+                Short.MIN_VALUE + 1,
+                Short.MAX_VALUE,
+                -0.075,
+                0.075));
+
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvInt(new byte[] {
+                40}, TARGET_LOCATION_LATITUDE), Integer.MIN_VALUE + 1, Integer.MAX_VALUE, -90, 90));
+
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvInt(new byte[] {
+                41}, TARGET_LOCATION_LONGITUDE),
+                Integer.MIN_VALUE + 1,
+                Integer.MAX_VALUE,
+                -180,
+                180));
+
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvUnsignedShort(new byte[] {
+                42}, TARGET_LOCATION_ELEVATION), 0, MAX_UNSIGNED_SHORT, -900, 19000));
+
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvLong(new byte[] {
+                57}, GROUND_RANGE), 0, MAX_UNSIGNED_INT, 0, 5000000));
+
+        localSetContext.addDataElement(new KlvString(new byte[] {59}, PLATFORM_CALL_SIGN));
+        localSetContext.addDataElement(new KlvLong(new byte[] {72}, EVENT_START_TIME));
+        localSetContext.addDataElement(new KlvUnsignedByte(new byte[] {77}, OPERATIONAL_MODE));
+
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvInt(new byte[] {
+                82}, CORNER_LATITUDE_1), Integer.MIN_VALUE + 1, Integer.MAX_VALUE, -90, 90));
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvInt(new byte[] {
+                83}, CORNER_LONGITUDE_1), Integer.MIN_VALUE + 1, Integer.MAX_VALUE, -180, 180));
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvInt(new byte[] {
+                84}, CORNER_LATITUDE_2), Integer.MIN_VALUE + 1, Integer.MAX_VALUE, -90, 90));
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvInt(new byte[] {
+                85}, CORNER_LONGITUDE_2), Integer.MIN_VALUE + 1, Integer.MAX_VALUE, -180, 180));
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvInt(new byte[] {
+                86}, CORNER_LATITUDE_3), Integer.MIN_VALUE + 1, Integer.MAX_VALUE, -90, 90));
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvInt(new byte[] {
+                87}, CORNER_LONGITUDE_3), Integer.MIN_VALUE + 1, Integer.MAX_VALUE, -180, 180));
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvInt(new byte[] {
+                88}, CORNER_LATITUDE_4), Integer.MIN_VALUE + 1, Integer.MAX_VALUE, -90, 90));
+        localSetContext.addDataElement(new KlvIntegerEncodedFloatingPoint(new KlvInt(new byte[] {
+                89}, CORNER_LONGITUDE_4), Integer.MIN_VALUE + 1, Integer.MAX_VALUE, -180, 180));
+
+        final KlvContext securityLocalSetContext = new KlvContext(KeyLength.OneByte,
+                LengthEncoding.BER);
+
+        securityLocalSetContext.addDataElement(new KlvUnsignedByte(new byte[] {1},
+                SECURITY_CLASSIFICATION));
+        securityLocalSetContext.addDataElement(new KlvUnsignedByte(new byte[] {2},
+                CLASSIFYING_COUNTRY_CODING_METHOD));
+        securityLocalSetContext.addDataElement(new KlvUnsignedByte(new byte[] {3},
+                CLASSIFYING_COUNTRY));
+        securityLocalSetContext.addDataElement(new KlvUnsignedByte(new byte[] {12},
+                OBJECT_COUNTRY_CODING_METHOD));
+        securityLocalSetContext.addDataElement(new KlvUnsignedByte(new byte[] {13},
+                OBJECT_COUNTRY_CODES));
+
+        localSetContext.addDataElement(new KlvLocalSet(new byte[] {48},
+                SECURITY_LOCAL_METADATA_SET,
+                securityLocalSetContext));
+
+        UAS_DATALINK_LOCAL_SET_CONTEXT.addDataElement(outerSet);
+    }
+
+    private final MpegTransportStreamMetadataExtractor extractor;
+
+    private final KlvDecoder decoder;
+
+    /**
+     * Constructs a {@code Stanag4609TransportStreamParser} with the given {@link ByteSource} as the
+     * provider of the transport stream bytes.
+     *
+     * @param byteSource the {@code ByteSource} providing the transport stream bytes
+     */
+    public Stanag4609TransportStreamParser(final ByteSource byteSource) {
+        extractor = new MpegTransportStreamMetadataExtractor(byteSource);
+        decoder = new KlvDecoder(UAS_DATALINK_LOCAL_SET_CONTEXT);
+    }
+
+    /**
+     * Parses the transport stream and calls the given callback for each decoded KLV metadata packet
+     * in each metadata stream found in the transport stream. The callback is called immediately
+     * upon finding a complete KLV metadata packet.
+     *
+     * @param callback a callback that will be called for each decoded KLV metadata packet in each
+     *                 metadata stream found in the transport stream, where the first parameter is
+     *                 the packet ID of the metadata stream and the second parameter is the decoded
+     *                 metadata packet
+     * @throws Exception if the transport stream cannot be parsed
+     */
+    public void parse(final BiConsumer<Integer, DecodedKLVMetadataPacket> callback)
+            throws Exception {
+        extractor.getMetadata((klvStreamPid, pesPacketBytes) -> {
+            try {
+                final DecodedKLVMetadataPacket decodedKLVMetadataPacket = handlePESPacketBytes(
+                        pesPacketBytes);
+                if (decodedKLVMetadataPacket != null) {
+                    callback.accept(klvStreamPid, decodedKLVMetadataPacket);
+                }
+            } catch (KlvDecodingException e) {
+                LOGGER.debug("The KLV could not be decoded.", e);
+            } catch (RuntimeException e) {
+                LOGGER.debug("An error occurred while handling the metadata packet bytes.", e);
+            }
+        });
+    }
+
+    /**
+     * Parses the transport stream and returns all the decoded KLV metadata packets (in the order in
+     * which they were encountered) that belong to each metadata stream.
+     *
+     * @return a {@link Map} whose keys are the packet IDs of the metadata streams and whose values
+     * are the decoded KLV metadata packets belonging to that stream
+     * @throws Exception if the transport stream cannot be parsed
+     */
+    public Map<Integer, List<DecodedKLVMetadataPacket>> parse() throws Exception {
+        final Map<Integer, List<DecodedKLVMetadataPacket>> decodedStreams = new HashMap<>();
+
+        parse((klvStreamPid, decodedKLVMetadataUnit) -> {
+            if (!decodedStreams.containsKey(klvStreamPid)) {
+                decodedStreams.put(klvStreamPid, new ArrayList<>());
+            }
+
+            decodedStreams.get(klvStreamPid)
+                    .add(decodedKLVMetadataUnit);
+        });
+
+        return decodedStreams;
+    }
+
+    private DecodedKLVMetadataPacket handlePESPacketBytes(final byte[] pesPacketBytes)
+            throws KlvDecodingException {
+        final PESPacket pesHeader = MPSUtils.readPESHeader(ByteBuffer.wrap(pesPacketBytes), 0);
+
+        if (pesHeader.streamId == METADATA_STREAM_ID) {
+            return new SynchronousMetadataPacket(pesPacketBytes, pesHeader, decoder).decodeKLV();
+        } else if (pesHeader.streamId == PRIVATE_STREAM_ID) {
+            return new AsynchronousMetadataPacket(pesPacketBytes, pesHeader, decoder).decodeKLV();
+        } else {
+            LOGGER.debug("Unknown stream type {}. Skipping this packet.", pesHeader.streamId);
+        }
+        return null;
+    }
+}

--- a/libs/stanag4609/src/main/java/org/codice/alliance/libs/stanag4609/SynchronousMetadataPacket.java
+++ b/libs/stanag4609/src/main/java/org/codice/alliance/libs/stanag4609/SynchronousMetadataPacket.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.libs.stanag4609;
+
+import java.util.Arrays;
+
+import org.codice.ddf.libs.klv.KlvDecoder;
+import org.jcodec.containers.mps.MPSDemuxer.PESPacket;
+
+class SynchronousMetadataPacket extends AbstractMetadataPacket {
+    private static final int SYNCHRONOUS_PES_PACKET_HEADER_LENGTH = 14;
+
+    private static final int METADATA_ACCESS_UNIT_HEADER_LENGTH = 5;
+
+    SynchronousMetadataPacket(final byte[] pesPacketBytes, final PESPacket pesHeader,
+            final KlvDecoder decoder) {
+        super(pesPacketBytes, pesHeader, decoder);
+    }
+
+    @Override
+    protected byte[] getKLVBytes() {
+        // For synchronous metadata streams, the header is supposed to be 14 bytes long. The header's
+        // length field gives the number of bytes in the packet following it, so we need to skip
+        // the 8 header bytes after the length field to get the true length of the payload.
+        final byte[] metadataAccessUnit = getPESPacketPayload(pesHeader.length - 8,
+                SYNCHRONOUS_PES_PACKET_HEADER_LENGTH);
+
+        if (metadataAccessUnit.length > METADATA_ACCESS_UNIT_HEADER_LENGTH) {
+            return getKLVPayloadFromMetadataAccessUnit(metadataAccessUnit);
+        }
+
+        return null;
+    }
+
+    private byte[] getKLVPayloadFromMetadataAccessUnit(final byte[] metadataAccessUnit) {
+        final int payloadLength =
+                ((metadataAccessUnit[3] & 0xFF) << 8) | (metadataAccessUnit[4] & 0xFF);
+        final int payloadEnd = Math.min(metadataAccessUnit.length,
+                METADATA_ACCESS_UNIT_HEADER_LENGTH + payloadLength);
+        return Arrays.copyOfRange(metadataAccessUnit,
+                METADATA_ACCESS_UNIT_HEADER_LENGTH,
+                payloadEnd);
+    }
+}

--- a/libs/stanag4609/src/test/java/org/codice/alliance/libs/stanag4609/MetadataPacketTest.java
+++ b/libs/stanag4609/src/test/java/org/codice/alliance/libs/stanag4609/MetadataPacketTest.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.libs.stanag4609;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertThat;
+
+import java.nio.ByteBuffer;
+
+import org.codice.ddf.libs.klv.KlvContext;
+import org.codice.ddf.libs.klv.KlvDecoder;
+import org.codice.ddf.libs.klv.KlvDecodingException;
+import org.codice.ddf.libs.klv.data.numerical.KlvUnsignedShort;
+import org.codice.ddf.libs.klv.data.set.KlvLocalSet;
+import org.jcodec.containers.mps.MPSUtils;
+import org.junit.Test;
+
+public class MetadataPacketTest {
+    @Test
+    public void testSynchronousMetadataPacket() throws Exception {
+        final byte[] pesPacketBytes =
+                new byte[] {0x00, 0x00, 0x01, (byte) 0xFC, 0x00, 0x22, (byte) 0x85, (byte) 0x80,
+                        0x00, 0x27, 0x19, 0x2B, 0x33, (byte) 0x91, 0x01, 0x01, 0x01, 0x00, 0x15,
+                        0x06, 0x0E, 0x2B, 0x34, 0x02, 0x0B, 0x01, 0x01, 0x0E, 0x01, 0x03, 0x01,
+                        0x01, 0x00, 0x00, 0x00, 0x04, 0x01, 0x02, 0x4C, 0x51};
+
+        final SynchronousMetadataPacket packet = new SynchronousMetadataPacket(pesPacketBytes,
+                MPSUtils.readPESHeader(ByteBuffer.wrap(pesPacketBytes), 0),
+                new KlvDecoder(Stanag4609TransportStreamParser.UAS_DATALINK_LOCAL_SET_CONTEXT));
+        final DecodedKLVMetadataPacket decodedPacket = packet.decodeKLV();
+
+        verifyDecodedKLV(decodedPacket);
+
+        final long presentationTimestamp = 3326777800L;
+        assertThat(decodedPacket.getPresentationTimestamp(), is(presentationTimestamp));
+    }
+
+    @Test
+    public void testSynchronousMetadataPacketMetadataAccessUnitTooShort() throws Exception {
+        final byte[] pesPacketBytes =
+                new byte[] {0x00, 0x00, 0x01, (byte) 0xFC, 0x00, 0x0C, (byte) 0x85, (byte) 0x80,
+                        0x00, 0x27, 0x19, 0x2B, 0x33, (byte) 0x91, 0x01, 0x01, 0x01, 0x00};
+
+        final SynchronousMetadataPacket packet = new SynchronousMetadataPacket(pesPacketBytes,
+                MPSUtils.readPESHeader(ByteBuffer.wrap(pesPacketBytes), 0),
+                new KlvDecoder(Stanag4609TransportStreamParser.UAS_DATALINK_LOCAL_SET_CONTEXT));
+        assertThat(packet.decodeKLV(), nullValue());
+    }
+
+    @Test
+    public void testAsynchronousMetadataPacket() throws Exception {
+        final byte[] pesPacketBytes =
+                new byte[] {0x00, 0x00, 0x01, (byte) 0xBD, 0x00, 0x18, (byte) 0x85, (byte) 0x00,
+                        0x00, 0x06, 0x0E, 0x2B, 0x34, 0x02, 0x0B, 0x01, 0x01, 0x0E, 0x01, 0x03,
+                        0x01, 0x01, 0x00, 0x00, 0x00, 0x04, 0x01, 0x02, 0x4C, 0x51};
+
+        final AsynchronousMetadataPacket packet = new AsynchronousMetadataPacket(pesPacketBytes,
+                MPSUtils.readPESHeader(ByteBuffer.wrap(pesPacketBytes), 0),
+                new KlvDecoder(Stanag4609TransportStreamParser.UAS_DATALINK_LOCAL_SET_CONTEXT));
+        final DecodedKLVMetadataPacket decodedPacket = packet.decodeKLV();
+        verifyDecodedKLV(decodedPacket);
+
+        assertThat(decodedPacket.getPresentationTimestamp(), is(lessThan(0L)));
+    }
+
+    private void verifyDecodedKLV(final DecodedKLVMetadataPacket decodedPacket) {
+        assertThat(decodedPacket, notNullValue());
+
+        assertThat(decodedPacket.getDecodedKLV()
+                .hasDataElement(Stanag4609TransportStreamParser.UAS_DATALINK_LOCAL_SET), is(true));
+
+        final KlvContext localSetContext = ((KlvLocalSet) decodedPacket.getDecodedKLV()
+                .getDataElementByName(Stanag4609TransportStreamParser.UAS_DATALINK_LOCAL_SET)).getValue();
+        assertThat(((KlvUnsignedShort) localSetContext.getDataElementByName(
+                Stanag4609TransportStreamParser.CHECKSUM)).getValue(), is(19537));
+    }
+
+    @Test(expected = KlvDecodingException.class)
+    public void testWrongChecksum() throws Exception {
+        final byte[] pesPacketBytes =
+                new byte[] {0x00, 0x00, 0x01, (byte) 0xBD, 0x00, 0x18, (byte) 0x85, (byte) 0x00,
+                        0x00, 0x06, 0x0E, 0x2B, 0x34, 0x02, 0x0B, 0x01, 0x01, 0x0E, 0x01, 0x03,
+                        0x01, 0x01, 0x00, 0x00, 0x00, 0x04, 0x01, 0x02, 0x4C, 0x52};
+
+        final AsynchronousMetadataPacket packet = new AsynchronousMetadataPacket(pesPacketBytes,
+                MPSUtils.readPESHeader(ByteBuffer.wrap(pesPacketBytes), 0),
+                new KlvDecoder(Stanag4609TransportStreamParser.UAS_DATALINK_LOCAL_SET_CONTEXT));
+        packet.decodeKLV();
+    }
+
+    @Test(expected = KlvDecodingException.class)
+    public void testChecksumMissingUASDatalinkLocalSet() throws Exception {
+        final byte[] pesPacketBytes =
+                new byte[] {0x00, 0x00, 0x01, (byte) 0xBD, 0x00, 0x18, (byte) 0x85, (byte) 0x00,
+                        0x00, 0x06, 0x0E, 0x2B, 0x34, 0x02, 0x0B, 0x01, 0x01, 0x0E, 0x01, 0x03,
+                        0x01, 0x01, 0x00, 0x00, 0x01, 0x04, 0x01, 0x02, 0x4C, 0x52};
+
+        final AsynchronousMetadataPacket packet = new AsynchronousMetadataPacket(pesPacketBytes,
+                MPSUtils.readPESHeader(ByteBuffer.wrap(pesPacketBytes), 0),
+                new KlvDecoder(Stanag4609TransportStreamParser.UAS_DATALINK_LOCAL_SET_CONTEXT));
+        packet.decodeKLV();
+    }
+
+    @Test(expected = KlvDecodingException.class)
+    public void testMissingChecksum() throws Exception {
+        final byte[] pesPacketBytes =
+                new byte[] {0x00, 0x00, 0x01, (byte) 0xBD, 0x00, 0x18, (byte) 0x85, (byte) 0x00,
+                        0x00, 0x06, 0x0E, 0x2B, 0x34, 0x02, 0x0B, 0x01, 0x01, 0x0E, 0x01, 0x03,
+                        0x01, 0x01, 0x00, 0x00, 0x00, 0x04, 0x06, 0x02, 0x01, 0x01};
+
+        final AsynchronousMetadataPacket packet = new AsynchronousMetadataPacket(pesPacketBytes,
+                MPSUtils.readPESHeader(ByteBuffer.wrap(pesPacketBytes), 0),
+                new KlvDecoder(Stanag4609TransportStreamParser.UAS_DATALINK_LOCAL_SET_CONTEXT));
+        packet.decodeKLV();
+    }
+}

--- a/libs/stanag4609/src/test/java/org/codice/alliance/libs/stanag4609/Stanag4609TransportStreamParserTest.java
+++ b/libs/stanag4609/src/test/java/org/codice/alliance/libs/stanag4609/Stanag4609TransportStreamParserTest.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.alliance.libs.stanag4609;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import org.apache.commons.io.IOUtils;
+import org.codice.ddf.libs.klv.KlvContext;
+import org.codice.ddf.libs.klv.KlvDataElement;
+import org.codice.ddf.libs.klv.data.set.KlvLocalSet;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.google.common.io.ByteSource;
+
+public class Stanag4609TransportStreamParserTest {
+    private static final Map<String, Object> EXPECTED_VALUES = new HashMap<>();
+
+    @BeforeClass
+    public static void setUpClass() {
+        EXPECTED_VALUES.put(Stanag4609TransportStreamParser.TIMESTAMP, 1245257585099653L);
+        EXPECTED_VALUES.put(Stanag4609TransportStreamParser.IMAGE_SOURCE_SENSOR, "EON");
+        EXPECTED_VALUES.put(Stanag4609TransportStreamParser.IMAGE_COORDINATE_SYSTEM,
+                "Geodetic WGS84");
+        EXPECTED_VALUES.put(Stanag4609TransportStreamParser.SENSOR_LATITUDE, 54.681323);
+        EXPECTED_VALUES.put(Stanag4609TransportStreamParser.SENSOR_LONGITUDE, -110.168559);
+        EXPECTED_VALUES.put(Stanag4609TransportStreamParser.SENSOR_TRUE_ALTITUDE, 1532.272831);
+        EXPECTED_VALUES.put(Stanag4609TransportStreamParser.SLANT_RANGE, 10928.624544);
+
+        // In this test file, target width is encoded in 4 bytes, but the standard says it should be
+        // encoded in 2.
+        EXPECTED_VALUES.put(Stanag4609TransportStreamParser.TARGET_WIDTH, 0.0);
+        EXPECTED_VALUES.put(Stanag4609TransportStreamParser.FRAME_CENTER_LATITUDE, 54.749123);
+        EXPECTED_VALUES.put(Stanag4609TransportStreamParser.FRAME_CENTER_LONGITUDE, -110.046638);
+        EXPECTED_VALUES.put(Stanag4609TransportStreamParser.FRAME_CENTER_ELEVATION, -4.522774);
+        EXPECTED_VALUES.put(Stanag4609TransportStreamParser.TARGET_LOCATION_LATITUDE, 54.749123);
+        EXPECTED_VALUES.put(Stanag4609TransportStreamParser.TARGET_LOCATION_LONGITUDE, -110.046638);
+        EXPECTED_VALUES.put(Stanag4609TransportStreamParser.TARGET_LOCATION_ELEVATION, -4.522774);
+        EXPECTED_VALUES.put(Stanag4609TransportStreamParser.GROUND_RANGE, 10820.674945);
+        EXPECTED_VALUES.put(Stanag4609TransportStreamParser.CHECKSUM, 7263);
+    }
+
+    private Stanag4609TransportStreamParser getParser() throws IOException {
+        final ByteSource byteSource =
+                ByteSource.wrap(IOUtils.toByteArray(getClass().getClassLoader()
+                        .getResourceAsStream("dayflight.mpg")));
+
+        return new Stanag4609TransportStreamParser(byteSource);
+    }
+
+    @Test
+    public void testParseTransportStreamWithKLVCallback() throws Exception {
+        final Stanag4609TransportStreamParser parser = getParser();
+
+        // Mockito can't spy anonymous classes.
+        final BiConsumer<Integer, DecodedKLVMetadataPacket> callback =
+                new BiConsumer<Integer, DecodedKLVMetadataPacket>() {
+                    @Override
+                    public void accept(Integer integer,
+                            DecodedKLVMetadataPacket decodedKLVMetadataPacket) {
+                    }
+                };
+        final BiConsumer<Integer, DecodedKLVMetadataPacket> callbackSpy = spy(callback);
+
+        parser.parse(callbackSpy);
+
+        final ArgumentCaptor<DecodedKLVMetadataPacket> decodedPacketCaptor =
+                ArgumentCaptor.forClass(DecodedKLVMetadataPacket.class);
+        // The packet ID of the metadata stream in this file is 497.
+        verify(callbackSpy, times(1)).accept(eq(497), decodedPacketCaptor.capture());
+        verifyDecodedMetadataPacket(decodedPacketCaptor.getValue());
+    }
+
+    @Test
+    public void testParseTransportStreamWithKLVAll() throws Exception {
+        final Stanag4609TransportStreamParser parser = getParser();
+
+        final Map<Integer, List<DecodedKLVMetadataPacket>> decodedStreams = parser.parse();
+
+        assertThat(decodedStreams.size(), is(1));
+        // The packet ID of the metadata stream in this file is 497.
+        assertThat(decodedStreams, hasKey(497));
+        final List<DecodedKLVMetadataPacket> decodedPackets = decodedStreams.get(497);
+        assertThat(decodedPackets.size(), is(1));
+        verifyDecodedMetadataPacket(decodedPackets.get(0));
+    }
+
+    private void verifyDecodedMetadataPacket(final DecodedKLVMetadataPacket packet) {
+        final KlvContext outerContext = packet.getDecodedKLV();
+        assertThat(outerContext.getDataElements()
+                .size(), is(1));
+
+        assertThat(outerContext.hasDataElement(Stanag4609TransportStreamParser.UAS_DATALINK_LOCAL_SET),
+                is(true));
+        final KlvContext localSetContext = ((KlvLocalSet) outerContext.getDataElementByName(
+                Stanag4609TransportStreamParser.UAS_DATALINK_LOCAL_SET)).getValue();
+        final Map<String, KlvDataElement> localSetDataElements = localSetContext.getDataElements();
+
+        assertThat(localSetDataElements.size(), is(EXPECTED_VALUES.size()));
+
+        localSetDataElements.forEach((name, dataElement) -> {
+            final Object expectedValue = EXPECTED_VALUES.get(name);
+            final Object actualValue = dataElement.getValue();
+
+            if (actualValue instanceof Double) {
+                assertThat(String.format("%s is not close to %s", name, expectedValue),
+                        (Double) actualValue,
+                        is(closeTo((Double) expectedValue, 1e-6)));
+            } else {
+                assertThat(String.format("%s is not %s", name, expectedValue),
+                        actualValue,
+                        is(expectedValue));
+            }
+        });
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,9 @@
         <cxf.version>3.1.4</cxf.version>
         <karaf.version>4.0.4</karaf.version>
         <commons-lang.version>2.6</commons-lang.version>
+        <commons-io.version>2.1</commons-io.version>
+        <guava.version>18.0</guava.version>
+        <slf4j.version>1.7.1</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <joda-time.version>2.2</joda-time.version>
         <jts.version>1.12</jts.version>
@@ -89,19 +92,19 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
-            <version>1.1</version>
+            <version>1.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>1.9.5</version>
+            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -452,5 +455,6 @@
     <modules>
         <module>catalog</module>
         <module>distribution</module>
+        <module>libs</module>
     </modules>
 </project>


### PR DESCRIPTION
#### What does this PR do?
- Add libs module
- Add stanag4609 module that provides the ability to extract KLV metadata from MPEG transport streams
- Add junit, hamcrest, and mockito to root pom dependencies

#### Who is reviewing it?
@jaymcnallie @kcwire @bdeining 

#### How should this be tested?
Do a full build.

#### Any background context you want to provide?
https://codice.atlassian.net/browse/CAL-20

#### What are the relevant tickets?
https://codice.atlassian.net/browse/CAL-20

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests