### PR TITLE
CAL-29 MPEG-TS/KLV Input Transformer

### DIFF
--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -61,6 +61,7 @@
     <modules>
         <module>nsili</module>
         <module>imaging</module>
+        <module>video</module>
     </modules>
 
     <build>

--- a/catalog/video/catalog-mpegts-transformer/pom.xml
+++ b/catalog/video/catalog-mpegts-transformer/pom.xml
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- 
+/**
+ * Copyright (c) Connexta, LLC
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>alliance-video</artifactId>
+        <groupId>com.connexta.alliance.video</groupId>
+        <version>0.1-SNAPSHOT</version>
+    </parent>
+    <artifactId>alliance-mpegts-transformer</artifactId>
+    <packaging>bundle</packaging>
+    <name>Alliance :: MPEGTS :: Transformer</name>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codice.ddf</groupId>
+            <artifactId>klv</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf</groupId>
+            <artifactId>mpeg-transport-stream</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.connexta.alliance</groupId>
+            <artifactId>stanag4609</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.connexta.alliance</groupId>
+            <artifactId>klv</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.vividsolutions</groupId>
+            <artifactId>jts</artifactId>
+            <version>${jts.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jcodec</groupId>
+            <artifactId>jcodec</artifactId>
+            <version>${jcodec.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.taktik</groupId>
+            <artifactId>mpegts-streamer</artifactId>
+            <version>${mpegts-streamer.version}</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-configs</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>src/main/resources/com_connexta_transformer_video_MpegTsInputTransformer.default.config</file>
+                                    <type>config</type>
+                                    <classifier>default</classifier>
+                                </artifact>
+                                <artifact>
+                                    <file>src/main/resources/DDF_Custom_Mime_Type_Resolver.mpegts.config</file>
+                                    <type>config</type>
+                                    <classifier>mpegts</classifier>
+                                </artifact>
+                                <artifact>
+                                    <file>src/main/resources/mpegTsMetacardType.json</file>
+                                    <type>json</type>
+                                    <classifier>mpegts</classifier>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Import-Package>
+                            !org.bouncycastle.crypto.*,
+                            ddf.catalog.transform.*,
+                            *
+                        </Import-Package>
+                        <Embed-Dependency>
+                            platform-util,
+                            catalog-core-api-impl,
+                            commons-collections4,
+                            commons-lang3,
+                            jcodec,
+                            mpegts-streamer
+                        </Embed-Dependency>
+                        <Export-Package/>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.79</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.37</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.41</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.92</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/catalog/video/catalog-mpegts-transformer/src/main/java/com/connexta/transformer/video/MpegTsInputTransformer.java
+++ b/catalog/video/catalog-mpegts-transformer/src/main/java/com/connexta/transformer/video/MpegTsInputTransformer.java
@@ -1,0 +1,201 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.transformer.video;
+
+import static org.apache.commons.lang3.Validate.notNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.connexta.alliance.libs.klv.KlvHandler;
+import com.connexta.alliance.libs.klv.KlvHandlerFactory;
+import com.connexta.alliance.libs.klv.KlvProcessor;
+import com.connexta.alliance.libs.klv.Stanag4609ParseException;
+import com.connexta.alliance.libs.klv.Stanag4609Parser;
+import com.connexta.alliance.libs.klv.Stanag4609Processor;
+import com.connexta.alliance.libs.klv.StanagParserFactory;
+import com.connexta.alliance.libs.stanag4609.DecodedKLVMetadataPacket;
+import com.google.common.io.FileBackedOutputStream;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.transform.CatalogTransformerException;
+import ddf.catalog.transform.InputTransformer;
+
+public class MpegTsInputTransformer implements InputTransformer {
+
+    public static final String CONTENT_TYPE = "video/mp2t";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MpegTsInputTransformer.class);
+
+    private static final int FILE_THRESHOLD = 1000000;
+
+    private static final Integer DEFAULT_SUBSAMPLE_COUNT = 50;
+
+    private final InputTransformer innerTransformer;
+
+    private final List<MetacardType> metacardTypes;
+
+    private final Stanag4609Processor stanag4609Processor;
+
+    private final KlvHandlerFactory klvHandlerFactory;
+
+    private final StanagParserFactory stanagParserFactory;
+
+    private final KlvProcessor klvProcessor;
+
+    /**
+     * The default handler is used to handle
+     * metadata elements that do not have a dedicated handler. This handler simply logs a message
+     * indicating that the metadata element is unhandled.
+     */
+    private final KlvHandler defaultKlvHandler;
+
+    private Integer subsampleCount = DEFAULT_SUBSAMPLE_COUNT;
+
+    /**
+     * @param inputTransformer    inner input transformer (must be non-null)
+     * @param metacardTypes       list of usable metacard types (must be non-null)
+     * @param stanag4609Processor must be non-null
+     * @param klvHandlerFactory   must be non-null
+     * @param defaultKlvHandler   must be non-null
+     * @param stanagParserFactory must be non-null
+     * @param klvProcessor        processors to transfer klv to metacard (must be non-null)
+     */
+    public MpegTsInputTransformer(InputTransformer inputTransformer,
+            List<MetacardType> metacardTypes, Stanag4609Processor stanag4609Processor,
+            KlvHandlerFactory klvHandlerFactory, KlvHandler defaultKlvHandler,
+            StanagParserFactory stanagParserFactory, KlvProcessor klvProcessor) {
+
+        notNull(inputTransformer, "The inputTransformer must be non-null");
+        notNull(metacardTypes, "The metacardTypes must be non-null");
+        notNull(stanag4609Processor, "The stanag4609Processor must be non-null");
+        notNull(klvHandlerFactory, "The klvHandlerFactory must be non-null");
+        notNull(defaultKlvHandler, "The defaultKlvHandler must be non-null");
+        notNull(stanagParserFactory, "The stanagParserFactory must be non-null");
+        notNull(klvProcessor, "The klvProcessor must be non-null");
+
+        this.innerTransformer = inputTransformer;
+        this.metacardTypes = metacardTypes;
+        this.stanag4609Processor = stanag4609Processor;
+        this.klvHandlerFactory = klvHandlerFactory;
+        this.stanagParserFactory = stanagParserFactory;
+        this.defaultKlvHandler = defaultKlvHandler;
+        this.klvProcessor = klvProcessor;
+    }
+
+    public void setSubsampleCount(Integer subsampleCount) {
+        this.subsampleCount = subsampleCount;
+    }
+
+    @Override
+    public Metacard transform(InputStream inputStream)
+            throws IOException, CatalogTransformerException {
+        return transform(inputStream, null);
+    }
+
+    @Override
+    public Metacard transform(InputStream inputStream, final String id)
+            throws IOException, CatalogTransformerException {
+
+        LOGGER.info("processing video input for id = {}", id);
+
+        try (FileBackedOutputStream fileBackedOutputStream = new FileBackedOutputStream(
+                FILE_THRESHOLD)) {
+
+            populateFileBackedOutputStream(inputStream, fileBackedOutputStream);
+
+            MetacardImpl metacard = extractInnerTransformerMetadata(id, fileBackedOutputStream);
+
+            extractStanag4609Metadata(metacard, fileBackedOutputStream);
+
+            return metacard;
+        }
+
+    }
+
+    private void populateFileBackedOutputStream(InputStream inputStream,
+            FileBackedOutputStream fbos) throws CatalogTransformerException {
+        try {
+            int c = IOUtils.copy(inputStream, fbos);
+            LOGGER.debug("copied {} bytes from input stream to file backed output stream", c);
+        } catch (IOException e) {
+            throw new CatalogTransformerException("Could not copy bytes of content message.", e);
+        }
+    }
+
+    /**
+     * Call the inner transformer with the content data and return a metacard based on
+     * {@link #metacardTypes} that is populated by the inner transformer and with the
+     * content type set to {@link #CONTENT_TYPE}.
+     *
+     * @param id
+     * @param fileBackedOutputStream
+     * @return metacard
+     * @throws IOException
+     * @throws CatalogTransformerException
+     */
+    private MetacardImpl extractInnerTransformerMetadata(String id,
+            FileBackedOutputStream fileBackedOutputStream)
+            throws IOException, CatalogTransformerException {
+
+        try (InputStream inputStream = fileBackedOutputStream.asByteSource()
+                .openStream()) {
+
+            MetacardType metacardType = metacardTypes.stream()
+                    .findFirst()
+                    .orElseThrow(() -> new CatalogTransformerException(
+                            "no matching metacard type found! id = " + id));
+
+            Metacard innerMetacard = innerTransformer.transform(inputStream, id);
+
+            MetacardImpl metacard = new MetacardImpl(innerMetacard, metacardType);
+
+            metacard.setContentTypeName(CONTENT_TYPE);
+
+            return metacard;
+        }
+    }
+
+    private void extractStanag4609Metadata(MetacardImpl metacard, FileBackedOutputStream fbos)
+            throws CatalogTransformerException {
+
+        Stanag4609Parser stanag4609Parser = stanagParserFactory.createParser(fbos.asByteSource());
+
+        Map<Integer, List<DecodedKLVMetadataPacket>> decodedMetadata;
+        try {
+            decodedMetadata = stanag4609Parser.parse();
+        } catch (Stanag4609ParseException e) {
+            throw new CatalogTransformerException("failed to extract STANAG 4609 metadata", e);
+        }
+
+        Map<String, KlvHandler> handlers = klvHandlerFactory.createStanag4609Handlers();
+
+        stanag4609Processor.handle(handlers, defaultKlvHandler, decodedMetadata);
+
+        KlvProcessor.Configuration klvProcessConfiguration = new KlvProcessor.Configuration();
+        klvProcessConfiguration.set(KlvProcessor.Configuration.SUBSAMPLE_COUNT, subsampleCount);
+
+        klvProcessor.process(handlers, metacard, klvProcessConfiguration);
+
+    }
+
+}

--- a/catalog/video/catalog-mpegts-transformer/src/main/resources/DDF_Custom_Mime_Type_Resolver.mpegts.config
+++ b/catalog/video/catalog-mpegts-transformer/src/main/resources/DDF_Custom_Mime_Type_Resolver.mpegts.config
@@ -1,0 +1,4 @@
+customMimeTypes=["ts\=video/mp2t"]
+name="MPEG-TS\ Content\ Resolver"
+priority=I"10"
+service.factoryPid="DDF_Custom_Mime_Type_Resolver"

--- a/catalog/video/catalog-mpegts-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/video/catalog-mpegts-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Connexta, LLC
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<blueprint xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0" xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+    <reference id="tikaInputTransformer" interface="ddf.catalog.transform.InputTransformer" filter="(id=tika)"
+               availability="mandatory"/>
+
+    <reference-list id="metacardTypeList" interface="ddf.catalog.data.MetacardType" filter="(name=MpegTsMetacardType)" availability="mandatory" />
+
+    <bean id="transformer" class="com.connexta.transformer.video.MpegTsInputTransformer">
+
+        <cm:managed-properties persistent-id="com.connexta.transformer.video.MpegTsInputTransformer"
+                               update-strategy="container-managed" />
+        <argument ref="tikaInputTransformer"/>
+        <argument ref="metacardTypeList"/>
+        <argument>
+            <bean class="com.connexta.alliance.libs.klv.Stanag4609ProcessorImpl">
+                <argument>
+                    <bean class="com.connexta.alliance.libs.klv.OffsetCenterPostProcessor"/>
+                </argument>
+            </bean>
+        </argument>
+        <argument>
+            <bean class="com.connexta.alliance.libs.klv.KlvHandlerFactoryImpl"/>
+        </argument>
+        <argument>
+            <bean class="com.connexta.alliance.libs.klv.LoggingKlvHandler"/>
+        </argument>
+        <argument>
+            <bean class="com.connexta.alliance.libs.klv.StanagParserFactoryImpl"/>
+        </argument>
+        <argument>
+            <bean class="com.connexta.alliance.libs.klv.ListKlvProcessor">
+                <argument>
+                    <list>
+                        <bean class="com.connexta.alliance.libs.klv.LocationKlvProcessor"/>
+                        <bean class="com.connexta.alliance.libs.klv.SetDatesKlvProcessor"/>
+                        <bean class="com.connexta.alliance.libs.klv.MissionIdKlvProcessor"/>
+                        <bean class="com.connexta.alliance.libs.klv.PlatformDesignationKlvProcessor"/>
+                        <bean class="com.connexta.alliance.libs.klv.ImageSourceSensorKlvProcessor"/>
+                        <bean class="com.connexta.alliance.libs.klv.ObjectCountryCodesKlvProcessor"/>
+                        <bean class="com.connexta.alliance.libs.klv.SecurityClassificationKlvProcessor"/>
+                        <bean class="com.connexta.alliance.libs.klv.FrameCenterKlvProcessor"/>
+                        <bean class="com.connexta.alliance.libs.klv.ClassifyingCountryKlvProcessor"/>
+                    </list>
+                </argument>
+            </bean>
+        </argument>
+    </bean>
+
+    <service ref="transformer" interface="ddf.catalog.transform.InputTransformer">
+        <service-properties>
+            <entry key="id" value="mpegts"/>
+            <!-- shortname only exists for backwards compatibility -->
+            <entry key="shortname" value="mpegts"/>
+            <entry key="title" value="MPEGTS Input Transformer"/>
+            <entry key="description"
+                   value="Extracts stanag 4609 metadata from MPEG-TS files"/>
+            <entry key="mime-type">
+                <list>
+                    <value>video/mp2t</value>
+                </list>
+            </entry>
+        </service-properties>
+    </service>
+
+</blueprint>

--- a/catalog/video/catalog-mpegts-transformer/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/video/catalog-mpegts-transformer/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Connexta, LLC
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+    <OCD description="MPEG-TS Input Transformer"
+         name="MPEG-TS Input Transformer"
+         id="com.connexta.transformer.video.MpegTsInputTransformer">
+
+        <AD description="Location polygon subsample count used to reduce the number the total number of polygons."
+            name="Subsample Count" id="subsampleCount" required="true" type="Integer"
+            default="50"/>
+
+    </OCD>
+
+    <Designate pid="com.connexta.transformer.video.MpegTsInputTransformer">
+        <Object ocdref="com.connexta.transformer.video.MpegTsInputTransformer"/>
+    </Designate>
+
+</metatype:MetaData>

--- a/catalog/video/catalog-mpegts-transformer/src/main/resources/com_connexta_transformer_video_MpegTsInputTransformer.default.config
+++ b/catalog/video/catalog-mpegts-transformer/src/main/resources/com_connexta_transformer_video_MpegTsInputTransformer.default.config
@@ -1,0 +1,1 @@
+subsampleCount=I"50"

--- a/catalog/video/catalog-mpegts-transformer/src/main/resources/mpegTsMetacardType.json
+++ b/catalog/video/catalog-mpegts-transformer/src/main/resources/mpegTsMetacardType.json
@@ -1,0 +1,101 @@
+{
+  "metacardTypes": [
+    {
+      "type": "MpegTsMetacardType",
+      "attributes": {
+        "mission-id":{
+          "required":false
+        },
+        "platform-designation":{
+          "required":false
+        },
+        "image-source-sensor":{
+          "required":false
+        },
+        "frame-center-location":{
+          "required":false
+        },
+        "security-classification":{
+          "required":false
+        },
+        "classifying-country":{
+          "required":false
+        },
+        "object-country-codes":{
+          "required":false
+        },
+        "temporal.start":{
+          "required":false
+        },
+        "temporal.end":{
+          "required":false
+        }
+      }
+    }
+  ],
+  "attributeTypes":{
+    "mission-id":{
+      "type":"STRING_TYPE",
+      "stored": true,
+      "indexed": false,
+      "tokenized": false,
+      "multivalued": true
+    },
+    "platform-designation":{
+      "type":"STRING_TYPE",
+      "stored": true,
+      "indexed": false,
+      "tokenized": false,
+      "multivalued": true
+    },
+    "image-source-sensor":{
+      "type":"STRING_TYPE",
+      "stored": true,
+      "indexed": false,
+      "tokenized": false,
+      "multivalued": true
+    },
+    "frame-center-location":{
+      "type":"GEO_TYPE",
+      "stored": true,
+      "indexed": false,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "security-classification":{
+      "type":"SHORT_TYPE",
+      "stored": true,
+      "indexed": false,
+      "tokenized": false,
+      "multivalued": true
+    },
+    "classifying-country":{
+      "type":"STRING_TYPE",
+      "stored": true,
+      "indexed": false,
+      "tokenized": false,
+      "multivalued": true
+    },
+    "object-country-codes":{
+      "type":"STRING_TYPE",
+      "stored": true,
+      "indexed": false,
+      "tokenized": false,
+      "multivalued": true
+    },
+    "temporal.start":{
+      "type":"DATE_TYPE",
+      "stored": true,
+      "indexed": false,
+      "tokenized": false,
+      "multivalued": false
+    },
+    "temporal.end":{
+      "type":"DATE_TYPE",
+      "stored": true,
+      "indexed": false,
+      "tokenized": false,
+      "multivalued": false
+    }
+  }
+}

--- a/catalog/video/catalog-mpegts-transformer/src/test/java/com/connexta/transformer/video/TestMpegTsInputTransformer.java
+++ b/catalog/video/catalog-mpegts-transformer/src/test/java/com/connexta/transformer/video/TestMpegTsInputTransformer.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.transformer.video;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.connexta.alliance.libs.klv.KlvHandler;
+import com.connexta.alliance.libs.klv.KlvHandlerFactory;
+import com.connexta.alliance.libs.klv.KlvProcessor;
+import com.connexta.alliance.libs.klv.Stanag4609ParseException;
+import com.connexta.alliance.libs.klv.Stanag4609Processor;
+import com.connexta.alliance.libs.klv.StanagParserFactory;
+import com.connexta.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.transform.CatalogTransformerException;
+import ddf.catalog.transform.InputTransformer;
+
+public class TestMpegTsInputTransformer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestMpegTsInputTransformer.class);
+
+    private List<MetacardType> metacardTypes;
+
+    private Stanag4609Processor stanag4609Processor;
+
+    private KlvHandlerFactory klvHandlerFactory;
+
+    private KlvHandler defaultKlvHandler;
+
+    private Stanag4609TransportStreamParser streamParser;
+
+    private MetacardImpl metacard;
+
+    private InputTransformer inputTransformer;
+
+    private StanagParserFactory stanagParserFactory;
+
+    private KlvProcessor klvProcessor;
+
+    @Before
+    public void setup() throws IOException, CatalogTransformerException {
+        metacardTypes = Collections.singletonList(mock(MetacardType.class));
+        stanag4609Processor = mock(Stanag4609Processor.class);
+        klvHandlerFactory = mock(KlvHandlerFactory.class);
+        defaultKlvHandler = mock(KlvHandler.class);
+        streamParser = mock(Stanag4609TransportStreamParser.class);
+        metacard = new MetacardImpl(BasicTypes.BASIC_METACARD);
+        inputTransformer = mock(InputTransformer.class);
+        stanagParserFactory = mock(StanagParserFactory.class);
+        klvProcessor = mock(KlvProcessor.class);
+        when(inputTransformer.transform(any(), any())).thenReturn(metacard);
+        when(stanagParserFactory.createParser(any())).thenReturn(() -> {
+                    try {
+                        return streamParser.parse();
+                    } catch (Exception e) {
+                        throw new Stanag4609ParseException(e);
+                    }
+                }
+
+        );
+    }
+
+    @Test
+    public void testCopyInputTransformerAttributes() throws Exception {
+
+        metacard.setContentTypeName("some/thing");
+        metacard.setMetadata("the metadata");
+
+        when(streamParser.parse()).thenReturn(Collections.emptyMap());
+
+        MpegTsInputTransformer t = new MpegTsInputTransformer(inputTransformer,
+                metacardTypes,
+                stanag4609Processor,
+                klvHandlerFactory,
+                defaultKlvHandler,
+                stanagParserFactory,
+                klvProcessor);
+
+        try (InputStream inputStream = new ByteArrayInputStream(new byte[] {})) {
+
+            Metacard finalMetacard = t.transform(inputStream);
+
+            assertThat(finalMetacard.getContentTypeName(), is(MpegTsInputTransformer.CONTENT_TYPE));
+            assertThat(finalMetacard.getMetadata(), is("the metadata"));
+
+        }
+
+    }
+
+    @Test(expected = CatalogTransformerException.class)
+    public void testStanagParseError() throws Exception {
+
+        when(streamParser.parse()).thenThrow(new RuntimeException());
+
+        MpegTsInputTransformer t = new MpegTsInputTransformer(inputTransformer,
+                metacardTypes,
+                stanag4609Processor,
+                klvHandlerFactory,
+                defaultKlvHandler,
+                stanagParserFactory,
+                klvProcessor);
+
+        try (InputStream inputStream = new ByteArrayInputStream(new byte[] {})) {
+            t.transform(inputStream);
+        }
+
+    }
+
+    @Test(expected = CatalogTransformerException.class)
+    public void testInputStreamReadError() throws Exception {
+
+        MpegTsInputTransformer t = new MpegTsInputTransformer(inputTransformer,
+                metacardTypes,
+                stanag4609Processor,
+                klvHandlerFactory,
+                defaultKlvHandler,
+                stanagParserFactory,
+                klvProcessor);
+
+        InputStream inputStream = mock(InputStream.class);
+        when(inputStream.read(any())).thenThrow(new IOException());
+
+        t.transform(inputStream);
+
+    }
+}

--- a/catalog/video/catalog-video-app/pom.xml
+++ b/catalog/video/catalog-video-app/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+/**
+ * Copyright (c) Connexta, LLC
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.connexta.alliance.video</groupId>
+        <artifactId>alliance-video</artifactId>
+        <version>0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>alliance-video-app</artifactId>
+    <packaging>pom</packaging>
+    <name>Alliance :: Video :: App</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/classes</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/main/resources</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.karaf.tooling</groupId>
+                <artifactId>karaf-maven-plugin</artifactId>
+                <version>${karaf.version}</version>
+                <executions>
+                    <execution>
+                        <id>kar</id>
+                        <goals>
+                            <goal>kar</goal>
+                        </goals>
+                        <configuration>
+                            <resourcesDir>${project.build.directory}/resources</resourcesDir>
+                            <featuresFile>${basedir}/target/classes/features.xml</featuresFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Puts the features XML file for this app into the maven repo. -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-artifacts</id>
+                        <phase>package</phase>
+                        <inherited>false</inherited>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>target/classes/features.xml</file>
+                                    <type>xml</type>
+                                    <classifier>features</classifier>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/catalog/video/catalog-video-app/src/main/resources/features.xml
+++ b/catalog/video/catalog-video-app/src/main/resources/features.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) Connexta, LLC
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<features name="${project.artifactId}-${project.version}"
+          xmlns="http://karaf.apache.org/xmlns/features/v1.3.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
+
+    <feature name="video-app" install="auto" version="${project.version}"
+             description="The Alliance Video Application provides support for ingesting and searching for MPEG-TS products.  ::Alliance Video">
+        <feature prerequisite="true">catalog-app</feature>
+        <feature prerequisite="true">catalog-core-validator</feature>
+        <bundle>mvn:com.connexta.alliance/stanag4609/${project.version}</bundle>
+        <bundle>mvn:com.connexta.alliance/klv/${project.version}</bundle>
+        <bundle>mvn:org.codice.ddf/klv/${ddf.version}</bundle>
+        <bundle>mvn:org.codice.ddf/mpeg-transport-stream/${ddf.version}</bundle>
+        <bundle>mvn:com.connexta.alliance.video/alliance-mpegts-transformer/${project.version}</bundle>
+        <configfile finalname="/etc/DDF_Custom_Mime_Type_Resolver.mpegts.config">mvn:com.connexta.alliance.video/alliance-mpegts-transformer/${project.version}/config/mpegts</configfile>
+        <configfile finalname="/etc/definitions/MpegTsMetacardType.json">mvn:com.connexta.alliance.video/alliance-mpegts-transformer/${project.version}/json/mpegts</configfile>
+    </feature>
+</features>

--- a/catalog/video/pom.xml
+++ b/catalog/video/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Connexta, LLC
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <groupId>com.connexta.alliance</groupId>
+        <artifactId>catalog</artifactId>
+        <version>0.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>alliance-video</artifactId>
+    <groupId>com.connexta.alliance.video</groupId>
+    <packaging>pom</packaging>
+    <name>Alliance :: Video</name>
+
+    <modules>
+        <module>catalog-mpegts-transformer</module>
+        <module>catalog-video-app</module>
+    </modules>
+</project>

--- a/distribution/alliance/pom.xml
+++ b/distribution/alliance/pom.xml
@@ -138,6 +138,13 @@
             <type>xml</type>
         </dependency>
         <dependency>
+            <groupId>com.connexta.alliance.video</groupId>
+            <artifactId>alliance-video-app</artifactId>
+            <version>${project.version}</version>
+            <classifier>features</classifier>
+            <type>xml</type>
+        </dependency>
+        <dependency>
             <groupId>com.connexta.alliance.distribution</groupId>
             <artifactId>webconsole-branding-plugin</artifactId>
             <version>${project.version}</version>
@@ -230,6 +237,9 @@
                                 </descriptor>
                                 <descriptor>
                                     mvn:com.connexta.alliance.imaging/alliance-imaging-app/${project.version}/xml/features
+                                </descriptor>
+                                <descriptor>
+                                    mvn:com.connexta.alliance.video/alliance-video-app/${project.version}/xml/features
                                 </descriptor>
                                 <descriptor>file:${basedir}/target/classes/alliance-features.xml
                                 </descriptor>

--- a/distribution/alliance/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/distribution/alliance/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -24,6 +24,7 @@ featuresRepositories= \
  mvn:com.connexta.alliance.nsili/nsili-app/${project.version}/xml/features, \
  mvn:com.connexta.alliance.distribution/install-profiles/${project.version}/xml/features, \
  mvn:com.connexta.alliance.imaging/alliance-imaging-app/${project.version}/xml/features, \
+ mvn:com.connexta.alliance.video/alliance-video-app/${project.version}/xml/features, \
  mvn:org.codice.ddf/kernel/${ddf.version}/xml/features, \
  mvn:ddf.platform/platform-app/${ddf.version}/xml/features, \
  mvn:ddf.security/security-services-app/${ddf.version}/xml/features, \

--- a/distribution/install-profiles/src/main/resources/features.xml
+++ b/distribution/install-profiles/src/main/resources/features.xml
@@ -51,6 +51,7 @@
         <!-- Experimental Apps-->
         <feature>resourcemanagement-app</feature>
         <feature>geowebcache-app</feature>
+        <feature>video-app</feature>
     </feature>
 
 </features>

--- a/libs/klv/pom.xml
+++ b/libs/klv/pom.xml
@@ -22,26 +22,29 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>stanag4609</artifactId>
-    <name>Alliance :: STANAG 4609</name>
+    <artifactId>klv</artifactId>
+    <name>Alliance :: KLV</name>
     <packaging>bundle</packaging>
 
     <dependencies>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+            <version>${ddf.version}</version>
         </dependency>
+
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+            <version>${ddf.version}</version>
         </dependency>
+
         <dependency>
-            <groupId>org.jcodec</groupId>
-            <artifactId>jcodec</artifactId>
-            <version>${jcodec.version}</version>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+            <version>${ddf.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.codice.ddf</groupId>
             <artifactId>klv</artifactId>
@@ -52,12 +55,61 @@
             <artifactId>mpeg-transport-stream</artifactId>
             <version>${ddf.version}</version>
         </dependency>
+
         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>${commons-io.version}</version>
-            <scope>test</scope>
+            <groupId>com.connexta.alliance</groupId>
+            <artifactId>stanag4609</artifactId>
+            <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.vividsolutions</groupId>
+            <artifactId>jts</artifactId>
+            <version>${jts.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jcodec</groupId>
+            <artifactId>jcodec</artifactId>
+            <version>${jcodec.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.taktik</groupId>
+            <artifactId>mpegts-streamer</artifactId>
+            <version>${mpegts-streamer.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -68,8 +120,19 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package>com.connexta.alliance.libs.klv</Export-Package>
+                        <Import-Package>
+                            !org.bouncycastle.crypto.*,
+                            ddf.catalog.transform.*,
+                            *
+                        </Import-Package>
                         <Embed-Dependency>
-                            jcodec
+                            platform-util,
+                            catalog-core-api-impl,
+                            commons-collections4,
+                            commons-lang3,
+                            jcodec,
+                            mpegts-streamer
                         </Embed-Dependency>
                     </instructions>
                 </configuration>
@@ -92,17 +155,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.97</minimum>
+                                            <minimum>0.91</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.87</minimum>
+                                            <minimum>0.60</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.90</minimum>
+                                            <minimum>0.69</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/AttributeNameConstants.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/AttributeNameConstants.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import ddf.catalog.data.Metacard;
+
+/**
+ * All classes with this klv library should use these constants for metacard attribute names, even
+ * for names already defined in {@link Metacard} so that all attribute names used by the library
+ * are in a central location.
+ */
+public class AttributeNameConstants {
+
+    public static final String TEMPORAL_START = "temporal.start";
+
+    public static final String TEMPORAL_END = "temporal.end";
+
+    public static final String CREATED = Metacard.CREATED;
+
+    public static final String MISSION_ID = "mission-id";
+
+    public static final String PLATFORM_TAIL_NUMBER = "platform-tail-number";
+
+    public static final String PLATFORM_DESIGNATION = "platform-designation";
+
+    public static final String OFFSET_CORNER = "offset-corner-location";
+
+    public static final String TIMESTAMP = "timestamp";
+
+    public static final String PLATFORM_CALL_SIGN = "platform-call-sign";
+
+    public static final String EVENT_START_TIME = "event-start-time";
+
+    public static final String OPERATIONAL_MODE = "operational-mode";
+
+    public static final String CORNER = "corner-location";
+
+    public static final String SECURITY_CLASSIFICATION = "security-classification";
+
+    public static final String CLASSIFYING_COUNTRY_CODING_METHOD =
+            "classifying-country-coding-method";
+
+    public static final String CLASSIFYING_COUNTRY = "classifying-country";
+
+    public static final String OBJECT_COUNTRY_CODING_METHOD = "object-country-coding-method";
+
+    public static final String OBJECT_COUNTRY_CODES = "object-country-codes";
+
+    public static final String CHECKSUM = "checksum";
+
+    public static final String IMAGE_COORDINATE_SYSTEM = "image-coordinate-system";
+
+    public static final String IMAGE_SOURCE_SENSOR = "image-source-sensor";
+
+    public static final String TARGET_WIDTH = "target-width";
+
+    public static final String FRAME_CENTER_ELEVATION = "frame-center-elevation";
+
+    public static final String SENSOR_TRUE_ALTITUDE = "sensor-true-altitude";
+
+    public static final String GROUND_RANGE = "ground-range";
+
+    public static final String SLANT_RANGE = "slant-range";
+
+    public static final String TARGET_LOCATION_ELEVATION = "target-location-elevation";
+
+    public static final String FRAME_CENTER = "frame-center-location";
+
+    public static final String TARGET_LOCATION = "target-location";
+
+    public static final String SENSOR = "sensor";
+
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/BaseKlvHandler.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/BaseKlvHandler.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.impl.AttributeImpl;
+
+abstract class BaseKlvHandler implements KlvHandler {
+
+    private String attributeName;
+
+    public BaseKlvHandler(String attributeName) {
+        this.attributeName = attributeName;
+    }
+
+    @Override
+    public String getAttributeName() {
+        return this.attributeName;
+    }
+
+    protected final <T extends Serializable> Optional<Attribute> asAttribute(Collection<T> col) {
+        if (col.isEmpty()) {
+            return Optional.empty();
+        }
+        List<Serializable> serials = new LinkedList<>(col);
+        return Optional.of(new AttributeImpl(getAttributeName(), serials));
+    }
+
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/ClassifyingCountryKlvProcessor.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/ClassifyingCountryKlvProcessor.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import com.connexta.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
+
+public class ClassifyingCountryKlvProcessor extends DistinctKlvProcessor {
+    public ClassifyingCountryKlvProcessor() {
+        super(AttributeNameConstants.CLASSIFYING_COUNTRY,
+                Stanag4609TransportStreamParser.CLASSIFYING_COUNTRY);
+    }
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/CopyPresentKlvProcessor.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/CopyPresentKlvProcessor.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import java.util.Map;
+
+import ddf.catalog.data.Metacard;
+
+/**
+ * For each handler, call its asAttribute() method and add the result to the metacard.
+ */
+public class CopyPresentKlvProcessor implements KlvProcessor {
+
+    @Override
+    public void process(Map<String, KlvHandler> handlers, Metacard metacard,
+            Configuration configuration) {
+        handlers.values()
+                .stream()
+                .distinct()
+                .forEach(handler -> handler.asAttribute()
+                        .ifPresent(metacard::setAttribute));
+    }
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/DistinctKlvProcessor.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/DistinctKlvProcessor.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import java.util.stream.Collectors;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+
+/**
+ * Reduces a list of attribute values returned by the KLV handlers to a list of distinct values
+ * and adds those values to the metacard.
+ */
+public class DistinctKlvProcessor extends SingleFieldKlvProcessor {
+
+    private final String attributeName;
+
+    protected DistinctKlvProcessor(String attributeName, String stanagFieldName) {
+        super(stanagFieldName);
+        this.attributeName = attributeName;
+    }
+
+    @Override
+    protected void doProcess(Attribute attribute, Metacard metacard) {
+        metacard.setAttribute(new AttributeImpl(attributeName,
+                attribute.getValues()
+                        .stream()
+                        .distinct()
+                        .collect(Collectors.toList())));
+    }
+
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/FrameCenterKlvProcessor.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/FrameCenterKlvProcessor.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.connexta.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.LineString;
+import com.vividsolutions.jts.io.WKTReader;
+import com.vividsolutions.jts.io.WKTWriter;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+
+/**
+ * Uses {@link Stanag4609TransportStreamParser#FRAME_CENTER_LATITUDE} and
+ * {@link Stanag4609TransportStreamParser#FRAME_CENTER_LONGITUDE} to generate a WKT LINESTRING
+ * and store it in the metacard attribute {@link AttributeNameConstants#FRAME_CENTER}.
+ */
+public class FrameCenterKlvProcessor extends MultipleFieldKlvProcessor {
+
+    /**
+     * The name of the metacard attribute being set.
+     */
+    private static final String ATTRIBUTE_NAME = AttributeNameConstants.FRAME_CENTER;
+
+    public FrameCenterKlvProcessor() {
+        super(Arrays.asList(Stanag4609TransportStreamParser.FRAME_CENTER_LATITUDE,
+                Stanag4609TransportStreamParser.FRAME_CENTER_LONGITUDE));
+    }
+
+    @Override
+    protected void doProcess(Attribute attribute, Metacard metacard) {
+        List<String> points = getAttributeStrings(attribute);
+
+        Coordinate[] coordinates = listToArray(convertWktToCoordinates(points));
+
+        LineString lineString = convertCoordinatesToLineString(coordinates);
+
+        String wkt = convertLineStringToWkt(lineString);
+
+        setAttribute(metacard, wkt);
+
+    }
+
+    private void setAttribute(Metacard metacard, String wkt) {
+        metacard.setAttribute(new AttributeImpl(ATTRIBUTE_NAME, wkt));
+    }
+
+    private Coordinate[] listToArray(List<Coordinate> coordinateList) {
+        return coordinateList.toArray(new Coordinate[coordinateList.size()]);
+    }
+
+    private String convertLineStringToWkt(LineString lineString) {
+        WKTWriter wktWriter = new WKTWriter();
+        return wktWriter.write(lineString.norm());
+    }
+
+    private LineString convertCoordinatesToLineString(Coordinate[] coordinates) {
+        return new GeometryFactory().createLineString(coordinates);
+    }
+
+    private List<Coordinate> convertWktToCoordinates(List<String> points) {
+        WKTReader wktReader = new WKTReader();
+        return points.stream()
+                .map(wkt -> GeometryUtility.wktToGeometry(wkt, wktReader))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .map(Geometry::getCoordinate)
+                .collect(Collectors.toList());
+    }
+
+    private List<String> getAttributeStrings(Attribute attribute) {
+        return attribute.getValues()
+                .stream()
+                .filter(serializable -> serializable instanceof String)
+                .map(serializable -> (String) serializable)
+                .collect(Collectors.toList());
+    }
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/GeoBoxHandler.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/GeoBoxHandler.java
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.codice.ddf.libs.klv.KlvDataElement;
+import org.codice.ddf.libs.klv.data.numerical.KlvIntegerEncodedFloatingPoint;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.Attribute;
+
+/**
+ * This handler expects four latitude-longitude pairs. It generates a WKT polygon for each four-pair set.
+ */
+class GeoBoxHandler extends BaseKlvHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GeoBoxHandler.class);
+
+    private String latitude1;
+
+    private String longitude1;
+
+    private String latitude2;
+
+    private String longitude2;
+
+    private String latitude3;
+
+    private String longitude3;
+
+    private String latitude4;
+
+    private String longitude4;
+
+    private Map<String, List<Double>> map = new HashMap<>();
+
+    /**
+     * @param attributeName the name of the metacard attribute being generated
+     * @param latitude1     the name of the stanag 4609 field
+     * @param longitude1    the name of the stanag 4609 field
+     * @param latitude2     the name of the stanag 4609 field
+     * @param longitude2    the name of the stanag 4609 field
+     * @param latitude3     the name of the stanag 4609 field
+     * @param longitude3    the name of the stanag 4609 field
+     * @param latitude4     the name of the stanag 4609 field
+     * @param longitude4    the name of the stanag 4609 field
+     */
+    public GeoBoxHandler(String attributeName, String latitude1, String longitude1,
+            String latitude2, String longitude2, String latitude3, String longitude3,
+            String latitude4, String longitude4) {
+        super(attributeName);
+
+        this.latitude1 = latitude1;
+        this.longitude1 = longitude1;
+
+        this.latitude2 = latitude2;
+        this.longitude2 = longitude2;
+
+        this.latitude3 = latitude3;
+        this.longitude3 = longitude3;
+
+        this.latitude4 = latitude4;
+        this.longitude4 = longitude4;
+
+    }
+
+    public String getLatitude1() {
+        return latitude1;
+    }
+
+    public String getLatitude2() {
+        return latitude2;
+    }
+
+    public String getLatitude3() {
+        return latitude3;
+    }
+
+    public String getLatitude4() {
+        return latitude4;
+    }
+
+    public String getLongitude1() {
+        return longitude1;
+    }
+
+    public String getLongitude2() {
+        return longitude2;
+    }
+
+    public String getLongitude3() {
+        return longitude3;
+    }
+
+    public String getLongitude4() {
+        return longitude4;
+    }
+
+    public Map<String, List<Double>> getRawGeoData() {
+        return map;
+    }
+
+    @Override
+    public Optional<Attribute> asAttribute() {
+
+        int minimumListSize = map.values()
+                .stream()
+                .min((a, b) -> Integer.compare(a.size(), b.size()))
+                .orElse(Collections.emptyList())
+                .size();
+
+        List<String> polygonsWkts = new ArrayList<>();
+
+        for (int i = 0; i < minimumListSize; i++) {
+            polygonsWkts.add(String.format("POLYGON ((%f %f, %f %f, %f %f, %f %f, %f %f))",
+                    map.get(longitude1)
+                            .get(i),
+                    map.get(latitude1)
+                            .get(i),
+                    map.get(longitude2)
+                            .get(i),
+                    map.get(latitude2)
+                            .get(i),
+                    map.get(longitude3)
+                            .get(i),
+                    map.get(latitude3)
+                            .get(i),
+                    map.get(longitude4)
+                            .get(i),
+                    map.get(latitude4)
+                            .get(i),
+                    map.get(longitude1)
+                            .get(i),
+                    map.get(latitude1)
+                            .get(i)));
+        }
+
+        return asAttribute(polygonsWkts);
+    }
+
+    @Override
+    public void accept(KlvDataElement klvDataElement) {
+        if (!(klvDataElement instanceof KlvIntegerEncodedFloatingPoint)) {
+            LOGGER.warn(
+                    "non-KlvIntegerEncodedFloatingPoint data was passed to the GeoBoxHandler: name = {} klvDataElement = {}",
+                    klvDataElement.getName(),
+                    klvDataElement);
+            return;
+        }
+        accept(klvDataElement.getName(),
+                ((KlvIntegerEncodedFloatingPoint) klvDataElement).getValue());
+    }
+
+    public void accept(String name, Double value) {
+        map.putIfAbsent(name, new ArrayList<>());
+        map.get(name)
+                .add(value);
+    }
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/GeometryUtility.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/GeometryUtility.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKTReader;
+import com.vividsolutions.jts.io.WKTWriter;
+
+import ddf.catalog.data.Attribute;
+
+class GeometryUtility {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GeometryUtility.class);
+
+    /**
+     * Create the union of multi-valued attribute that contains WKT. If the union cannot
+     * be computed, then this method returns {@link Optional#empty()}
+     *
+     * @param wktReader non-null
+     * @param wktWriter non-null
+     * @param attribute non-null
+     * @return optional wkt string
+     */
+    public static Optional<String> createUnionOfGeometryAttribute(WKTReader wktReader,
+            WKTWriter wktWriter, Attribute attribute) {
+        return attribute.getValues()
+                .stream()
+                .filter(serializable -> serializable instanceof String)
+                .map(s -> (String) s)
+                .map(wkt -> wktToGeometry(wkt, wktReader))
+                .reduce(GeometryUtility::geometryUnion)
+                .orElse(Optional.<Geometry>empty())
+                .map(wktWriter::write);
+    }
+
+    private static Optional<Geometry> geometryUnion(Optional<Geometry> geometry1,
+            Optional<Geometry> geometry2) {
+        if (geometry1.isPresent() && geometry2.isPresent()) {
+            return Optional.of(geometry1.get()
+                    .union(geometry2.get()));
+        } else if (geometry1.isPresent()) {
+            return geometry1;
+        } else if (geometry2.isPresent()) {
+            return geometry2;
+        }
+        return Optional.empty();
+    }
+
+    public static Optional<Geometry> wktToGeometry(String wkt, WKTReader wktReader) {
+        try {
+            return Optional.of(wktReader.read(wkt));
+        } catch (ParseException e) {
+            LOGGER.warn("unable to convert WKT to a Geometry object: wkt={}", wkt, e);
+        }
+        return Optional.empty();
+    }
+
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/ImageSourceSensorKlvProcessor.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/ImageSourceSensorKlvProcessor.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import com.connexta.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
+
+public class ImageSourceSensorKlvProcessor extends DistinctKlvProcessor {
+    public ImageSourceSensorKlvProcessor() {
+        super(AttributeNameConstants.IMAGE_SOURCE_SENSOR,
+                Stanag4609TransportStreamParser.IMAGE_SOURCE_SENSOR);
+    }
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/KlvHandler.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/KlvHandler.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import java.util.Optional;
+
+import org.codice.ddf.libs.klv.KlvDataElement;
+
+import ddf.catalog.data.Attribute;
+
+/**
+ * The KlvHandler receives STANAG 4609 data with the {@link #accept(KlvDataElement)} method
+ * and generates an optional {@link Attribute} with the {@link #asAttribute()} method.
+ */
+public interface KlvHandler {
+
+    /**
+     * Get the name of the metacard attribute that is associated with this handler.
+     *
+     * @return name of metacard attribute
+     */
+    String getAttributeName();
+
+    /**
+     * After {@link #accept(KlvDataElement)} has been called with all of the incoming data, this
+     * method will convert it to an {@link Attribute}. If there is insufficient data to create
+     * an Attribute, then the Optional will be empty.
+     *
+     * @return optional attribute
+     */
+    Optional<Attribute> asAttribute();
+
+    /**
+     * The handler accepts the incoming KLV metadata. If the incoming KLV metadata is not the
+     * datatype expected by this handler, then the handler should log a warning and return.
+     *
+     * @param klvDataElement incoming klv metadata
+     */
+    void accept(KlvDataElement klvDataElement);
+
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/KlvHandlerFactory.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/KlvHandlerFactory.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import java.util.Map;
+
+public interface KlvHandlerFactory {
+    Map<String, KlvHandler> createStanag4609Handlers();
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/KlvHandlerFactoryImpl.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/KlvHandlerFactoryImpl.java
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.codice.ddf.libs.klv.data.numerical.KlvIntegerEncodedFloatingPoint;
+import org.codice.ddf.libs.klv.data.numerical.KlvUnsignedByte;
+import org.codice.ddf.libs.klv.data.numerical.KlvUnsignedShort;
+import org.codice.ddf.libs.klv.data.text.KlvString;
+
+import com.connexta.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
+
+public class KlvHandlerFactoryImpl implements KlvHandlerFactory {
+
+    @Override
+    public Map<String, KlvHandler> createStanag4609Handlers() {
+        final Map<String, KlvHandler> handlers = new HashMap<>();
+
+        handlers.put(Stanag4609TransportStreamParser.MISSION_ID,
+                new ListOfBasicKlvDataTypesHandler<>(AttributeNameConstants.MISSION_ID,
+                        KlvString.class));
+
+        handlers.put(Stanag4609TransportStreamParser.PLATFORM_TAIL_NUMBER,
+                new ListOfBasicKlvDataTypesHandler<>(AttributeNameConstants.PLATFORM_TAIL_NUMBER,
+                        KlvString.class));
+
+        handlers.put(Stanag4609TransportStreamParser.PLATFORM_DESIGNATION,
+                new ListOfBasicKlvDataTypesHandler<>(AttributeNameConstants.PLATFORM_DESIGNATION,
+                        KlvString.class));
+
+        GeoBoxHandler offsetCornerHandler = new GeoBoxHandler(AttributeNameConstants.OFFSET_CORNER,
+                Stanag4609TransportStreamParser.OFFSET_CORNER_LATITUDE_1,
+                Stanag4609TransportStreamParser.OFFSET_CORNER_LONGITUDE_1,
+                Stanag4609TransportStreamParser.OFFSET_CORNER_LATITUDE_2,
+                Stanag4609TransportStreamParser.OFFSET_CORNER_LONGITUDE_2,
+                Stanag4609TransportStreamParser.OFFSET_CORNER_LATITUDE_3,
+                Stanag4609TransportStreamParser.OFFSET_CORNER_LONGITUDE_3,
+                Stanag4609TransportStreamParser.OFFSET_CORNER_LATITUDE_4,
+                Stanag4609TransportStreamParser.OFFSET_CORNER_LONGITUDE_4);
+        handlers.put(Stanag4609TransportStreamParser.OFFSET_CORNER_LATITUDE_1, offsetCornerHandler);
+        handlers.put(Stanag4609TransportStreamParser.OFFSET_CORNER_LONGITUDE_1,
+                offsetCornerHandler);
+        handlers.put(Stanag4609TransportStreamParser.OFFSET_CORNER_LATITUDE_2, offsetCornerHandler);
+        handlers.put(Stanag4609TransportStreamParser.OFFSET_CORNER_LONGITUDE_2,
+                offsetCornerHandler);
+        handlers.put(Stanag4609TransportStreamParser.OFFSET_CORNER_LATITUDE_3, offsetCornerHandler);
+        handlers.put(Stanag4609TransportStreamParser.OFFSET_CORNER_LONGITUDE_3,
+                offsetCornerHandler);
+        handlers.put(Stanag4609TransportStreamParser.OFFSET_CORNER_LATITUDE_4, offsetCornerHandler);
+        handlers.put(Stanag4609TransportStreamParser.OFFSET_CORNER_LONGITUDE_4,
+                offsetCornerHandler);
+
+        handlers.put(Stanag4609TransportStreamParser.PLATFORM_CALL_SIGN,
+                new ListOfBasicKlvDataTypesHandler<>(AttributeNameConstants.PLATFORM_CALL_SIGN,
+                        KlvString.class));
+
+        handlers.put(Stanag4609TransportStreamParser.EVENT_START_TIME,
+                new ListOfDatesHandler((AttributeNameConstants.EVENT_START_TIME)));
+
+        handlers.put(Stanag4609TransportStreamParser.OPERATIONAL_MODE,
+                new ListOfBasicKlvDataTypesHandler<>(AttributeNameConstants.OPERATIONAL_MODE,
+                        KlvUnsignedByte.class));
+
+        GeoBoxHandler cornerHandler = new GeoBoxHandler(AttributeNameConstants.CORNER,
+                Stanag4609TransportStreamParser.CORNER_LATITUDE_1,
+                Stanag4609TransportStreamParser.CORNER_LONGITUDE_1,
+                Stanag4609TransportStreamParser.CORNER_LATITUDE_2,
+                Stanag4609TransportStreamParser.CORNER_LONGITUDE_2,
+                Stanag4609TransportStreamParser.CORNER_LATITUDE_3,
+                Stanag4609TransportStreamParser.CORNER_LONGITUDE_3,
+                Stanag4609TransportStreamParser.CORNER_LATITUDE_4,
+                Stanag4609TransportStreamParser.CORNER_LONGITUDE_4);
+        handlers.put(Stanag4609TransportStreamParser.CORNER_LATITUDE_1, cornerHandler);
+        handlers.put(Stanag4609TransportStreamParser.CORNER_LONGITUDE_1, cornerHandler);
+        handlers.put(Stanag4609TransportStreamParser.CORNER_LATITUDE_2, cornerHandler);
+        handlers.put(Stanag4609TransportStreamParser.CORNER_LONGITUDE_2, cornerHandler);
+        handlers.put(Stanag4609TransportStreamParser.CORNER_LATITUDE_3, cornerHandler);
+        handlers.put(Stanag4609TransportStreamParser.CORNER_LONGITUDE_3, cornerHandler);
+        handlers.put(Stanag4609TransportStreamParser.CORNER_LATITUDE_4, cornerHandler);
+        handlers.put(Stanag4609TransportStreamParser.CORNER_LONGITUDE_4, cornerHandler);
+
+        handlers.put(Stanag4609TransportStreamParser.SECURITY_CLASSIFICATION,
+                new ListOfBasicKlvDataTypesHandler<>(AttributeNameConstants.SECURITY_CLASSIFICATION,
+                        KlvUnsignedByte.class));
+
+        handlers.put(Stanag4609TransportStreamParser.CLASSIFYING_COUNTRY_CODING_METHOD,
+                new ListOfBasicKlvDataTypesHandler<>(AttributeNameConstants.CLASSIFYING_COUNTRY_CODING_METHOD,
+                        KlvUnsignedByte.class));
+
+        handlers.put(Stanag4609TransportStreamParser.CLASSIFYING_COUNTRY,
+                new ListOfBasicKlvDataTypesHandler<>(AttributeNameConstants.CLASSIFYING_COUNTRY,
+                        KlvString.class));
+
+        handlers.put(Stanag4609TransportStreamParser.OBJECT_COUNTRY_CODING_METHOD,
+                new ListOfBasicKlvDataTypesHandler<>(AttributeNameConstants.OBJECT_COUNTRY_CODING_METHOD,
+                        KlvUnsignedByte.class));
+
+        handlers.put(Stanag4609TransportStreamParser.OBJECT_COUNTRY_CODES,
+                new ListOfBasicKlvDataTypesHandler<>(AttributeNameConstants.OBJECT_COUNTRY_CODES,
+                        KlvString.class));
+
+        handlers.put(Stanag4609TransportStreamParser.TIMESTAMP,
+                new ListOfDatesHandler(AttributeNameConstants.TIMESTAMP));
+
+        handlers.put(Stanag4609TransportStreamParser.CHECKSUM,
+                new ListOfBasicKlvDataTypesHandler<>(AttributeNameConstants.CHECKSUM,
+                        KlvUnsignedShort.class));
+
+        handlers.put(Stanag4609TransportStreamParser.IMAGE_COORDINATE_SYSTEM,
+                new ListOfBasicKlvDataTypesHandler<>(AttributeNameConstants.IMAGE_COORDINATE_SYSTEM,
+                        KlvString.class));
+
+        handlers.put(Stanag4609TransportStreamParser.IMAGE_SOURCE_SENSOR,
+                new ListOfBasicKlvDataTypesHandler<>(AttributeNameConstants.IMAGE_SOURCE_SENSOR,
+                        KlvString.class));
+
+        handlers.put(Stanag4609TransportStreamParser.TARGET_WIDTH,
+                new ListOfBasicKlvDataTypesHandler<>(AttributeNameConstants.TARGET_WIDTH,
+                        KlvIntegerEncodedFloatingPoint.class));
+
+        handlers.put(Stanag4609TransportStreamParser.FRAME_CENTER_ELEVATION,
+                new ListOfBasicKlvDataTypesHandler<>(AttributeNameConstants.FRAME_CENTER_ELEVATION,
+                        KlvIntegerEncodedFloatingPoint.class));
+
+        handlers.put(Stanag4609TransportStreamParser.SENSOR_TRUE_ALTITUDE,
+                new ListOfBasicKlvDataTypesHandler<>(AttributeNameConstants.SENSOR_TRUE_ALTITUDE,
+                        KlvIntegerEncodedFloatingPoint.class));
+
+        handlers.put(Stanag4609TransportStreamParser.GROUND_RANGE,
+                new ListOfBasicKlvDataTypesHandler<>(AttributeNameConstants.GROUND_RANGE,
+                        KlvIntegerEncodedFloatingPoint.class));
+
+        handlers.put(Stanag4609TransportStreamParser.SLANT_RANGE,
+                new ListOfBasicKlvDataTypesHandler<>(AttributeNameConstants.SLANT_RANGE,
+                        KlvIntegerEncodedFloatingPoint.class));
+
+        handlers.put(Stanag4609TransportStreamParser.TARGET_LOCATION_ELEVATION,
+                new ListOfBasicKlvDataTypesHandler<>(AttributeNameConstants.TARGET_LOCATION_ELEVATION,
+                        KlvIntegerEncodedFloatingPoint.class));
+
+        KlvHandler frameCenter = new LatitudeLongitudeHandler(AttributeNameConstants.FRAME_CENTER,
+                Stanag4609TransportStreamParser.FRAME_CENTER_LATITUDE,
+                Stanag4609TransportStreamParser.FRAME_CENTER_LONGITUDE);
+        handlers.put(Stanag4609TransportStreamParser.FRAME_CENTER_LONGITUDE, frameCenter);
+        handlers.put(Stanag4609TransportStreamParser.FRAME_CENTER_LATITUDE, frameCenter);
+
+        KlvHandler targetLocation =
+                new LatitudeLongitudeHandler(AttributeNameConstants.TARGET_LOCATION,
+                        Stanag4609TransportStreamParser.TARGET_LOCATION_LATITUDE,
+                        Stanag4609TransportStreamParser.TARGET_LOCATION_LONGITUDE);
+        handlers.put(Stanag4609TransportStreamParser.TARGET_LOCATION_LONGITUDE, targetLocation);
+        handlers.put(Stanag4609TransportStreamParser.TARGET_LOCATION_LATITUDE, targetLocation);
+
+        KlvHandler sensor = new LatitudeLongitudeHandler(AttributeNameConstants.SENSOR,
+                Stanag4609TransportStreamParser.SENSOR_LATITUDE,
+                Stanag4609TransportStreamParser.SENSOR_LONGITUDE);
+        handlers.put(Stanag4609TransportStreamParser.SENSOR_LONGITUDE, sensor);
+        handlers.put(Stanag4609TransportStreamParser.SENSOR_LATITUDE, sensor);
+
+        return handlers;
+
+    }
+
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/KlvProcessor.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/KlvProcessor.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import ddf.catalog.data.Metacard;
+
+/**
+ * A KlvProcessor is used to extract data from KlvHandlers and insert that data into a metacard.
+ */
+public interface KlvProcessor {
+
+    void process(Map<String, KlvHandler> handlers, Metacard metacard, Configuration configuration);
+
+    class Configuration {
+        public static final String SUBSAMPLE_COUNT = "subsample-count";
+
+        private Map<String, Object> configuration = new HashMap<>();
+
+        public void set(String name, Object value) {
+            configuration.put(name, value);
+        }
+
+        public Object get(String name) {
+            return configuration.get(name);
+        }
+    }
+
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/LatitudeLongitudeHandler.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/LatitudeLongitudeHandler.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.codice.ddf.libs.klv.KlvDataElement;
+import org.codice.ddf.libs.klv.data.numerical.KlvIntegerEncodedFloatingPoint;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.Attribute;
+
+/**
+ * This handler expects pairs of latitude and longitude values. It generates WKT Points.
+ */
+class LatitudeLongitudeHandler extends BaseKlvHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LatitudeLongitudeHandler.class);
+
+    private Map<String, List<Double>> map = new HashMap<>();
+
+    private String latitudeFieldName;
+
+    private String longitudeFieldName;
+
+    public LatitudeLongitudeHandler(String attributeName, String latitudeFieldName,
+            String longitudeFieldName) {
+        super(attributeName);
+        this.latitudeFieldName = latitudeFieldName;
+        this.longitudeFieldName = longitudeFieldName;
+    }
+
+    public String getLongitudeFieldName() {
+        return longitudeFieldName;
+    }
+
+    public String getLatitudeFieldName() {
+        return latitudeFieldName;
+    }
+
+    public Map<String, List<Double>> getRawGeoData() {
+        return map;
+    }
+
+    @Override
+    public Optional<Attribute> asAttribute() {
+
+        int minimumListSize = map.values()
+                .stream()
+                .min((a, b) -> Integer.compare(a.size(), b.size()))
+                .orElse(Collections.emptyList())
+                .size();
+
+        List<String> pairs = new ArrayList<>();
+
+        for (int i = 0; i < minimumListSize; i++) {
+            pairs.add(String.format("POINT (%f %f)",
+                    map.get(longitudeFieldName)
+                            .get(i),
+                    map.get(latitudeFieldName)
+                            .get(i)));
+        }
+
+        return asAttribute(pairs);
+    }
+
+    @Override
+    public void accept(KlvDataElement klvDataElement) {
+        if (!(klvDataElement instanceof KlvIntegerEncodedFloatingPoint)) {
+            LOGGER.warn(
+                    "non-KlvIntegerEncodedFloatingPoint data was passed to the LatitudeLongitudeHandler: name = {} klvDataElement = {}",
+                    klvDataElement.getName(),
+                    klvDataElement);
+            return;
+        }
+        map.putIfAbsent(klvDataElement.getName(), new ArrayList<>());
+        map.get(klvDataElement.getName())
+                .add(((KlvIntegerEncodedFloatingPoint) klvDataElement).getValue());
+    }
+
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/ListKlvProcessor.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/ListKlvProcessor.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import java.util.List;
+import java.util.Map;
+
+import ddf.catalog.data.Metacard;
+
+/**
+ * This {@link KlvProcessor} delegates to each KlvProcessor in a list of processors.
+ */
+public class ListKlvProcessor implements KlvProcessor {
+
+    private final List<KlvProcessor> klvProcessorList;
+
+    public ListKlvProcessor(List<KlvProcessor> klvProcessorList) {
+        this.klvProcessorList = klvProcessorList;
+    }
+
+    @Override
+    public void process(Map<String, KlvHandler> handlers, Metacard metacard,
+            Configuration configuration) {
+        klvProcessorList.forEach(klvProcessor -> klvProcessor.process(handlers,
+                metacard,
+                configuration));
+    }
+
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/ListOfBasicKlvDataTypesHandler.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/ListOfBasicKlvDataTypesHandler.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import java.io.Serializable;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+
+import org.codice.ddf.libs.klv.KlvDataElement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.Attribute;
+
+/**
+ * This handler expects a KlvDataElement that matches the Class passed into
+ * {@link #ListOfBasicKlvDataTypesHandler(String, Class)} generates a list of values returned by
+ * {@link KlvDataElement#getValue()}.
+ */
+class ListOfBasicKlvDataTypesHandler<T extends Serializable> extends BaseKlvHandler {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(ListOfBasicKlvDataTypesHandler.class);
+
+    private Class<? extends KlvDataElement<T>> clazz;
+
+    private List<T> list = new LinkedList<>();
+
+    public ListOfBasicKlvDataTypesHandler(String attributeName,
+            Class<? extends KlvDataElement<T>> clazz) {
+        super(attributeName);
+        this.clazz = clazz;
+    }
+
+    @Override
+    public Optional<Attribute> asAttribute() {
+        return asAttribute(list);
+    }
+
+    @Override
+    public void accept(KlvDataElement klvDataElement) {
+        if (!clazz.isInstance(klvDataElement)) {
+            LOGGER.warn(
+                    "non-{} data was passed to the ListOfBasicKlvDataTypesHandler: name = {} klvDataElement = {}",
+                    clazz.getName(),
+                    klvDataElement.getName(),
+                    klvDataElement);
+            return;
+        }
+        list.add(clazz.cast(klvDataElement)
+                .getValue());
+    }
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/ListOfDatesHandler.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/ListOfDatesHandler.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.codice.ddf.libs.klv.KlvDataElement;
+import org.codice.ddf.libs.klv.data.numerical.KlvLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.Attribute;
+
+/**
+ * This handler expects dates as microseconds since epoch and it generates a list of Dates.
+ */
+class ListOfDatesHandler extends BaseKlvHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ListOfDatesHandler.class);
+
+    private List<Date> dateList = new LinkedList<>();
+
+    public ListOfDatesHandler(String attributeName) {
+        super(attributeName);
+    }
+
+    @Override
+    public Optional<Attribute> asAttribute() {
+        return asAttribute(dateList);
+    }
+
+    @Override
+    public void accept(KlvDataElement klvDataElement) {
+        if (!(klvDataElement instanceof KlvLong)) {
+            LOGGER.warn(
+                    "non-KlvLong data was passed to the ListOfDatesHandler: name = {} klvDataElement = {}",
+                    klvDataElement.getName(),
+                    klvDataElement);
+            return;
+        }
+        dateList.add(new Date(TimeUnit.MICROSECONDS.toMillis(((KlvLong) klvDataElement).getValue())));
+    }
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/LocationKlvProcessor.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/LocationKlvProcessor.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.vividsolutions.jts.io.WKTReader;
+import com.vividsolutions.jts.io.WKTWriter;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+
+/**
+ * Generate the location metadata based on the klv corner data. Callers must supply a
+ * {@link Configuration} that contains a postive (>0)
+ * Integer for {@link Configuration#SUBSAMPLE_COUNT}.
+ */
+public class LocationKlvProcessor implements KlvProcessor {
+
+    public static final Integer MIN_SUBSAMPLE_COUNT = 1;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LocationKlvProcessor.class);
+
+    private Optional<KlvHandler> find(Map<String, KlvHandler> handlers, String name) {
+        return handlers.values()
+                .stream()
+                .filter(handler -> handler.getAttributeName()
+                        .equals(name))
+                .findFirst();
+    }
+
+    @Override
+    public void process(Map<String, KlvHandler> handlers, Metacard metacard,
+            Configuration configuration) {
+
+        if (configuration.get(Configuration.SUBSAMPLE_COUNT) == null || (Integer) configuration.get(
+                Configuration.SUBSAMPLE_COUNT) < MIN_SUBSAMPLE_COUNT) {
+            LOGGER.warn(
+                    "the subsample count configuration is missing or incorrectly configured (the minimum subsample count is {}), skipping location klv processing",
+                    MIN_SUBSAMPLE_COUNT);
+            return;
+        }
+
+        Integer subsampleCount = (Integer) configuration.get(Configuration.SUBSAMPLE_COUNT);
+
+        find(handlers, AttributeNameConstants.CORNER).ifPresent(cornerHandler -> {
+            if (cornerHandler instanceof GeoBoxHandler) {
+                subsample((GeoBoxHandler) cornerHandler, subsampleCount).asAttribute()
+                        .ifPresent(attribute -> setLocationFromCornerAttribute(metacard,
+                                attribute));
+            }
+        });
+
+    }
+
+    private void setLocationFromCornerAttribute(Metacard metacard, Attribute attribute) {
+        WKTReader wktReader = new WKTReader();
+        WKTWriter wktWriter = new WKTWriter();
+
+        GeometryUtility.createUnionOfGeometryAttribute(wktReader, wktWriter, attribute)
+                .ifPresent(location -> metacard.setAttribute(new AttributeImpl(Metacard.GEOGRAPHY,
+                        location)));
+
+    }
+
+    GeoBoxHandler subsample(GeoBoxHandler geoBoxHandler, Integer subsampleCount) {
+
+        if (geoBoxHandler.getRawGeoData()
+                .isEmpty()) {
+            return geoBoxHandler;
+        }
+
+        int size = geoBoxHandler.getRawGeoData()
+                .get(geoBoxHandler.getLatitude1())
+                .size();
+
+        if (size <= subsampleCount) {
+            return geoBoxHandler;
+        }
+
+        GeoBoxHandler out = new GeoBoxHandler(geoBoxHandler.getAttributeName(),
+                geoBoxHandler.getLatitude1(),
+                geoBoxHandler.getLongitude1(),
+                geoBoxHandler.getLatitude2(),
+                geoBoxHandler.getLongitude2(),
+                geoBoxHandler.getLatitude3(),
+                geoBoxHandler.getLongitude3(),
+                geoBoxHandler.getLatitude4(),
+                geoBoxHandler.getLongitude4());
+
+        geoBoxHandler.getRawGeoData()
+                .forEach((key, value) -> {
+                    for (int i = 0; i < subsampleCount; i++) {
+                        out.accept(key, value.get(i * size / subsampleCount));
+                    }
+                });
+
+        return out;
+    }
+
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/LoggingKlvHandler.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/LoggingKlvHandler.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import java.util.Optional;
+
+import org.codice.ddf.libs.klv.KlvDataElement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.Attribute;
+
+public class LoggingKlvHandler implements KlvHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoggingKlvHandler.class);
+
+    @Override
+    public String getAttributeName() {
+        return null;
+    }
+
+    @Override
+    public Optional<Attribute> asAttribute() {
+        return Optional.empty();
+    }
+
+    @Override
+    public void accept(KlvDataElement klvDataElement) {
+        LOGGER.warn("unhandled klv data element: name = {} value ={}",
+                klvDataElement.getName(),
+                klvDataElement);
+    }
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/MissionIdKlvProcessor.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/MissionIdKlvProcessor.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import com.connexta.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
+
+/**
+ * Map distinct values from {@link Stanag4609TransportStreamParser#MISSION_ID} to
+ * {@link AttributeNameConstants#MISSION_ID}.
+ */
+public class MissionIdKlvProcessor extends DistinctKlvProcessor {
+    public MissionIdKlvProcessor() {
+        super(AttributeNameConstants.MISSION_ID, Stanag4609TransportStreamParser.MISSION_ID);
+    }
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/MultipleFieldKlvProcessor.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/MultipleFieldKlvProcessor.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+
+public abstract class MultipleFieldKlvProcessor implements KlvProcessor {
+
+    private final List<String> stanagFieldNames;
+
+    public MultipleFieldKlvProcessor(List<String> stanagFieldNames) {
+        this.stanagFieldNames = stanagFieldNames;
+    }
+
+    @Override
+    public final void process(Map<String, KlvHandler> handlers, Metacard metacard,
+            Configuration configuration) {
+
+        List<KlvHandler> stanagHandlers = findKlvHandlers(handlers);
+
+        if (areAllHandlersFound(stanagHandlers)) {
+            callFirstHandler(metacard, stanagHandlers);
+        }
+
+    }
+
+    private void callFirstHandler(Metacard metacard, List<KlvHandler> stanagHandlers) {
+        stanagHandlers.stream()
+                .findFirst()
+                .ifPresent(handler -> handler.asAttribute()
+                        .ifPresent(attribute -> doProcess(attribute, metacard)));
+    }
+
+    private boolean areAllHandlersFound(List<KlvHandler> stanagHandlers) {
+        return stanagHandlers.size() == stanagFieldNames.size();
+    }
+
+    private List<KlvHandler> findKlvHandlers(Map<String, KlvHandler> handlers) {
+        return handlers.entrySet()
+                .stream()
+                .filter(entry -> stanagFieldNames.contains(entry.getKey()))
+                .map(Map.Entry::getValue)
+                .collect(Collectors.toList());
+    }
+
+    protected abstract void doProcess(Attribute attribute, Metacard metacard);
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/ObjectCountryCodesKlvProcessor.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/ObjectCountryCodesKlvProcessor.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import com.connexta.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
+
+public class ObjectCountryCodesKlvProcessor extends DistinctKlvProcessor {
+    public ObjectCountryCodesKlvProcessor() {
+        super(AttributeNameConstants.OBJECT_COUNTRY_CODES,
+                Stanag4609TransportStreamParser.OBJECT_COUNTRY_CODES);
+    }
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/OffsetCenterPostProcessor.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/OffsetCenterPostProcessor.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import java.util.Map;
+
+import org.codice.ddf.libs.klv.KlvDataElement;
+import org.codice.ddf.libs.klv.data.numerical.KlvIntegerEncodedFloatingPoint;
+
+import com.connexta.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
+
+/**
+ * Use frame center and offset corner data to calculate the corner data.
+ */
+public class OffsetCenterPostProcessor implements PostProcessor {
+
+    private boolean isCornerLatitude(Map<String, KlvHandler> handlers) {
+        return handlers.containsKey(Stanag4609TransportStreamParser.CORNER_LATITUDE_1) &&
+                handlers.containsKey(Stanag4609TransportStreamParser.CORNER_LATITUDE_2) &&
+                handlers.containsKey(Stanag4609TransportStreamParser.CORNER_LATITUDE_3) &&
+                handlers.containsKey(Stanag4609TransportStreamParser.CORNER_LATITUDE_4);
+    }
+
+    private boolean isCornerLongitude(Map<String, KlvHandler> handlers) {
+        return handlers.containsKey(Stanag4609TransportStreamParser.CORNER_LONGITUDE_1) &&
+                handlers.containsKey(Stanag4609TransportStreamParser.CORNER_LONGITUDE_2) &&
+                handlers.containsKey(Stanag4609TransportStreamParser.CORNER_LONGITUDE_3) &&
+                handlers.containsKey(Stanag4609TransportStreamParser.CORNER_LONGITUDE_4);
+    }
+
+    private boolean isOffsetCornerLatitude(Map<String, KlvDataElement> dataElements) {
+        return dataElements.containsKey(Stanag4609TransportStreamParser.OFFSET_CORNER_LATITUDE_1) &&
+                dataElements.containsKey(Stanag4609TransportStreamParser.OFFSET_CORNER_LATITUDE_2)
+                &&
+                dataElements.containsKey(Stanag4609TransportStreamParser.OFFSET_CORNER_LATITUDE_3)
+                &&
+                dataElements.containsKey(Stanag4609TransportStreamParser.OFFSET_CORNER_LATITUDE_4);
+    }
+
+    private boolean isOffsetCornerLongitude(Map<String, KlvDataElement> dataElements) {
+        return dataElements.containsKey(Stanag4609TransportStreamParser.OFFSET_CORNER_LONGITUDE_1)
+                &&
+                dataElements.containsKey(Stanag4609TransportStreamParser.OFFSET_CORNER_LONGITUDE_2)
+                &&
+                dataElements.containsKey(Stanag4609TransportStreamParser.OFFSET_CORNER_LONGITUDE_3)
+                &&
+                dataElements.containsKey(Stanag4609TransportStreamParser.OFFSET_CORNER_LONGITUDE_4);
+    }
+
+    private boolean isFrameCenter(Map<String, KlvDataElement> dataElements) {
+        return dataElements.containsKey(Stanag4609TransportStreamParser.FRAME_CENTER_LATITUDE)
+                && dataElements.containsKey(Stanag4609TransportStreamParser.FRAME_CENTER_LONGITUDE);
+    }
+
+    @Override
+    public void postProcess(Map<String, KlvDataElement> dataElements,
+            Map<String, KlvHandler> handlers) {
+
+        if (!(isCornerLatitude(handlers) && isCornerLongitude(handlers))) {
+            return;
+        }
+
+        if (isFrameCenter(dataElements) &&
+                isOffsetCornerLatitude(dataElements) && isOffsetCornerLongitude(dataElements)) {
+
+            doField(dataElements,
+                    handlers,
+                    Stanag4609TransportStreamParser.CORNER_LATITUDE_1,
+                    Stanag4609TransportStreamParser.OFFSET_CORNER_LATITUDE_1,
+                    Stanag4609TransportStreamParser.FRAME_CENTER_LATITUDE);
+
+            doField(dataElements,
+                    handlers,
+                    Stanag4609TransportStreamParser.CORNER_LONGITUDE_1,
+                    Stanag4609TransportStreamParser.OFFSET_CORNER_LONGITUDE_1,
+                    Stanag4609TransportStreamParser.FRAME_CENTER_LONGITUDE);
+
+            doField(dataElements,
+                    handlers,
+                    Stanag4609TransportStreamParser.CORNER_LATITUDE_2,
+                    Stanag4609TransportStreamParser.OFFSET_CORNER_LATITUDE_2,
+                    Stanag4609TransportStreamParser.FRAME_CENTER_LATITUDE);
+
+            doField(dataElements,
+                    handlers,
+                    Stanag4609TransportStreamParser.CORNER_LONGITUDE_2,
+                    Stanag4609TransportStreamParser.OFFSET_CORNER_LONGITUDE_2,
+                    Stanag4609TransportStreamParser.FRAME_CENTER_LONGITUDE);
+
+            doField(dataElements,
+                    handlers,
+                    Stanag4609TransportStreamParser.CORNER_LATITUDE_3,
+                    Stanag4609TransportStreamParser.OFFSET_CORNER_LATITUDE_3,
+                    Stanag4609TransportStreamParser.FRAME_CENTER_LATITUDE);
+
+            doField(dataElements,
+                    handlers,
+                    Stanag4609TransportStreamParser.CORNER_LONGITUDE_3,
+                    Stanag4609TransportStreamParser.OFFSET_CORNER_LONGITUDE_3,
+                    Stanag4609TransportStreamParser.FRAME_CENTER_LONGITUDE);
+
+            doField(dataElements,
+                    handlers,
+                    Stanag4609TransportStreamParser.CORNER_LATITUDE_4,
+                    Stanag4609TransportStreamParser.OFFSET_CORNER_LATITUDE_4,
+                    Stanag4609TransportStreamParser.FRAME_CENTER_LATITUDE);
+
+            doField(dataElements,
+                    handlers,
+                    Stanag4609TransportStreamParser.CORNER_LONGITUDE_4,
+                    Stanag4609TransportStreamParser.OFFSET_CORNER_LONGITUDE_4,
+                    Stanag4609TransportStreamParser.FRAME_CENTER_LONGITUDE);
+
+        }
+
+    }
+
+    private void doField(Map<String, KlvDataElement> dataElements, Map<String, KlvHandler> handlers,
+            String cornerField, String offsetField, String frameField) {
+
+        if (!(handlers.get(cornerField) instanceof GeoBoxHandler)) {
+            return;
+        }
+
+        if (!(dataElements.get(offsetField) instanceof KlvIntegerEncodedFloatingPoint)) {
+            return;
+        }
+
+        if (!(dataElements.get(frameField) instanceof KlvIntegerEncodedFloatingPoint)) {
+            return;
+        }
+
+        ((GeoBoxHandler) handlers.get(cornerField)).accept(cornerField,
+                ((KlvIntegerEncodedFloatingPoint) dataElements.get(offsetField)).getValue()
+                        + ((KlvIntegerEncodedFloatingPoint) dataElements.get(frameField)).getValue());
+
+    }
+
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/PlatformDesignationKlvProcessor.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/PlatformDesignationKlvProcessor.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import com.connexta.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
+
+public class PlatformDesignationKlvProcessor extends DistinctKlvProcessor {
+    public PlatformDesignationKlvProcessor() {
+        super(AttributeNameConstants.PLATFORM_DESIGNATION,
+                Stanag4609TransportStreamParser.PLATFORM_DESIGNATION);
+    }
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/PostProcessor.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/PostProcessor.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import java.util.Map;
+
+import org.codice.ddf.libs.klv.KlvDataElement;
+
+/**
+ * The PostProcessor is called after each klv metadata packet is processed. The primary purpose is
+ * to inject new metadata that is calculated from other metadata fields in the same klv metadata
+ * packet.
+ */
+public interface PostProcessor {
+
+    /**
+     * A typical implementation would search dataElements for specific instances, calculate a new
+     * value, and then call the KlvHandler in handlers that corresponds to the new data.
+     *
+     * @param dataElements map of klv data element names to klv data elements that were retrieved from the current klv metadata packet
+     * @param handlers     map of klv data element names to the handlers that process the klv data elements
+     */
+    void postProcess(Map<String, KlvDataElement> dataElements, Map<String, KlvHandler> handlers);
+
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/SecurityClassificationKlvProcessor.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/SecurityClassificationKlvProcessor.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import com.connexta.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
+
+public class SecurityClassificationKlvProcessor extends DistinctKlvProcessor {
+    public SecurityClassificationKlvProcessor() {
+        super(AttributeNameConstants.SECURITY_CLASSIFICATION,
+                Stanag4609TransportStreamParser.SECURITY_CLASSIFICATION);
+    }
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/SetDatesKlvProcessor.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/SetDatesKlvProcessor.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.connexta.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+
+/**
+ * Set the "temporal.start", "temporal.end" and "created" metacard attributes based on the klv
+ * metadata timestamp entries.
+ */
+public class SetDatesKlvProcessor extends SingleFieldKlvProcessor {
+
+    public SetDatesKlvProcessor() {
+        super(Stanag4609TransportStreamParser.TIMESTAMP);
+    }
+
+    @Override
+    protected void doProcess(Attribute attribute, Metacard metacard) {
+        List<Date> values = attribute.getValues()
+                .stream()
+                .filter(serializable -> serializable instanceof Date)
+                .map(s -> (Date) s)
+                .collect(Collectors.toList());
+
+        if (!values.isEmpty()) {
+            Date firstDate = values.get(0);
+            Date lastDate = values.get(values.size() - 1);
+            metacard.setAttribute(new AttributeImpl(AttributeNameConstants.TEMPORAL_START,
+                    firstDate));
+            metacard.setAttribute(new AttributeImpl(AttributeNameConstants.TEMPORAL_END, lastDate));
+            metacard.setAttribute(new AttributeImpl(AttributeNameConstants.CREATED, firstDate));
+        }
+    }
+
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/SingleFieldKlvProcessor.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/SingleFieldKlvProcessor.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import java.util.Collections;
+
+/**
+ * This class searches for the KlvHandler that corresponds to a stanag field name. If it is found,
+ * the KlvHandler#asAttribute() is called. If the method returns an Attribute, then
+ * #doProcess(Attribute, Metacard) is called.
+ */
+public abstract class SingleFieldKlvProcessor extends MultipleFieldKlvProcessor {
+    public SingleFieldKlvProcessor(String stanagFieldName) {
+        super(Collections.singletonList(stanagFieldName));
+    }
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/Stanag4609ParseException.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/Stanag4609ParseException.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+public class Stanag4609ParseException extends Exception {
+
+    public Stanag4609ParseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public Stanag4609ParseException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/Stanag4609Parser.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/Stanag4609Parser.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import java.util.List;
+import java.util.Map;
+
+import com.connexta.alliance.libs.stanag4609.DecodedKLVMetadataPacket;
+
+public interface Stanag4609Parser {
+    Map<Integer, List<DecodedKLVMetadataPacket>> parse() throws Stanag4609ParseException;
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/Stanag4609Processor.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/Stanag4609Processor.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import java.util.List;
+import java.util.Map;
+
+import org.codice.ddf.libs.klv.KlvContext;
+import org.codice.ddf.libs.klv.KlvDataElement;
+import org.codice.ddf.libs.klv.data.set.KlvLocalSet;
+
+import com.connexta.alliance.libs.stanag4609.DecodedKLVMetadataPacket;
+
+/**
+ * Handle the various KLV data elements/structures that returned by the STANAG 4609 parser. The
+ * main entry point is {@link #handle(Map, KlvHandler, Map)}.
+ */
+public interface Stanag4609Processor {
+    void handle(Map<String, KlvHandler> handlers, KlvHandler defaultHander,
+            Map<Integer, List<DecodedKLVMetadataPacket>> stanagMetadata);
+
+    void handle(Map<String, KlvHandler> handlers, KlvHandler defaultHandler, KlvContext klvContext,
+            Map<String, KlvDataElement> dataElements);
+
+    void handle(Map<String, KlvHandler> handlers, KlvHandler defaultHandler,
+            KlvDataElement klvDataElement, Map<String, KlvDataElement> dataElements);
+
+    void callDataElementHandlers(Map<String, KlvHandler> handlers, KlvHandler defaultHandler,
+            KlvDataElement klvDataElement, Map<String, KlvDataElement> dataElements);
+
+    void handle(Map<String, KlvHandler> handlers, KlvHandler defaultHandler,
+            KlvLocalSet klvLocalSet, Map<String, KlvDataElement> dataElements);
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/Stanag4609ProcessorImpl.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/Stanag4609ProcessorImpl.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.codice.ddf.libs.klv.KlvContext;
+import org.codice.ddf.libs.klv.KlvDataElement;
+import org.codice.ddf.libs.klv.data.set.KlvLocalSet;
+
+import com.connexta.alliance.libs.stanag4609.DecodedKLVMetadataPacket;
+
+public class Stanag4609ProcessorImpl implements Stanag4609Processor {
+
+    private PostProcessor postProcessor;
+
+    public Stanag4609ProcessorImpl(PostProcessor postProcessor) {
+        this.postProcessor = postProcessor;
+    }
+
+    /**
+     * Iterate through the STANAG 4609 metadata and pass each {@link DecodedKLVMetadataPacket}
+     * to {@link #handle(Map, KlvHandler, KlvContext, Map)}.
+     *
+     * @param handlers       map of klv handers
+     * @param stanagMetadata list of klv metadata packets
+     */
+    @Override
+    public void handle(Map<String, KlvHandler> handlers, KlvHandler defaultHander,
+            Map<Integer, List<DecodedKLVMetadataPacket>> stanagMetadata) {
+
+        stanagMetadata.values()
+                .stream()
+                .flatMap(List::stream)
+                .forEach(decodedKLVMetadataPacket -> {
+
+                    Map<String, KlvDataElement> dataElements = new HashMap<>();
+
+                    handle(handlers,
+                            defaultHander,
+                            decodedKLVMetadataPacket.getDecodedKLV(),
+                            dataElements);
+
+                    postProcessor.postProcess(dataElements, handlers);
+
+                });
+
+    }
+
+    /**
+     * Pass each KlvDataElement in the klvContext to {@link #handle(Map, KlvHandler, KlvDataElement, Map)}.
+     *
+     * @param handlers   map of klv handers
+     * @param klvContext klv context
+     */
+    @Override
+    public void handle(Map<String, KlvHandler> handlers, KlvHandler defaultHandler,
+            KlvContext klvContext, Map<String, KlvDataElement> dataElements) {
+        klvContext.getDataElements()
+                .values()
+                .forEach(klvDataElement -> handle(handlers,
+                        defaultHandler,
+                        klvDataElement,
+                        dataElements));
+    }
+
+    /**
+     * If klvDataElement is a KlvLocalSet, then pass it to {@link #handle(Map, KlvHandler, KlvLocalSet, Map)}.
+     * Otherwise, call the corresponding data element handler.
+     *
+     * @param handlers       map of klv handers
+     * @param klvDataElement klv data element
+     */
+    @Override
+    public void handle(Map<String, KlvHandler> handlers, KlvHandler defaultHandler,
+            KlvDataElement klvDataElement, Map<String, KlvDataElement> dataElements) {
+        if (klvDataElement instanceof KlvLocalSet) {
+            handle(handlers, defaultHandler, (KlvLocalSet) klvDataElement, dataElements);
+        } else {
+            callDataElementHandlers(handlers, defaultHandler, klvDataElement, dataElements);
+        }
+    }
+
+    /**
+     * Find and call the handler based on the name of the klvDataElement, otherwise use the default
+     * handler.
+     *
+     * @param handlers       map of klv handers
+     * @param klvDataElement klv data element
+     */
+    @Override
+    public void callDataElementHandlers(Map<String, KlvHandler> handlers, KlvHandler defaultHandler,
+            KlvDataElement klvDataElement, Map<String, KlvDataElement> dataElements) {
+        handlers.getOrDefault(klvDataElement.getName(), defaultHandler)
+                .accept(klvDataElement);
+        dataElements.put(klvDataElement.getName(), klvDataElement);
+    }
+
+    /**
+     * Pass the KlvContext within klvLocalSet to {@link #handle(Map, KlvHandler, KlvContext, Map)}.
+     *
+     * @param handlers    map of klv handers
+     * @param klvLocalSet klv local set
+     */
+    @Override
+    public void handle(Map<String, KlvHandler> handlers, KlvHandler defaultHandler,
+            KlvLocalSet klvLocalSet, Map<String, KlvDataElement> dataElements) {
+        handle(handlers, defaultHandler, klvLocalSet.getValue(), dataElements);
+    }
+
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/StanagParserFactory.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/StanagParserFactory.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import com.google.common.io.ByteSource;
+
+public interface StanagParserFactory {
+
+    Stanag4609Parser createParser(ByteSource byteSource);
+
+}

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/StanagParserFactoryImpl.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/StanagParserFactoryImpl.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import com.connexta.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
+import com.google.common.io.ByteSource;
+
+/**
+ * This factory returns a {@link Stanag4609Parser} that uses {@link Stanag4609TransportStreamParser}.
+ */
+public class StanagParserFactoryImpl implements StanagParserFactory {
+
+    @Override
+    public Stanag4609Parser createParser(ByteSource byteSource) {
+        return () -> {
+            try {
+                return new Stanag4609TransportStreamParser(byteSource).parse();
+            } catch (Exception e) {
+                throw new Stanag4609ParseException("unable to parse stanag 4609 data", e);
+            }
+        };
+    }
+
+}

--- a/libs/klv/src/test/java/com/connexta/alliance/libs/klv/KlvUtilities.java
+++ b/libs/klv/src/test/java/com/connexta/alliance/libs/klv/KlvUtilities.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.codice.ddf.libs.klv.KlvContext;
+import org.codice.ddf.libs.klv.KlvDataElement;
+import org.codice.ddf.libs.klv.KlvDecoder;
+import org.codice.ddf.libs.klv.KlvDecodingException;
+import org.codice.ddf.libs.klv.data.Klv;
+import org.codice.ddf.libs.klv.data.numerical.KlvInt;
+import org.codice.ddf.libs.klv.data.numerical.KlvIntegerEncodedFloatingPoint;
+import org.mockito.ArgumentCaptor;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+
+class KlvUtilities {
+
+    /**
+     * Helper for testing KlvProcessor implementations that derive from DistinctKlvProcessor.
+     *
+     * @param klvProcessor the processor being tested
+     * @param input        list of serializable values that are fed to the processor
+     * @return an argument captor of the attribute created by the processor
+     */
+    public static ArgumentCaptor<Attribute> testKlvProcessor(KlvProcessor klvProcessor,
+            String stangField, List<Serializable> input) {
+
+        Attribute attribute = mock(Attribute.class);
+
+        when(attribute.getValues()).thenReturn(input);
+
+        KlvHandler klvHandler = mock(KlvHandler.class);
+
+        when(klvHandler.asAttribute()).thenReturn(Optional.of(attribute));
+
+        Metacard metacard = mock(Metacard.class);
+
+        KlvProcessor.Configuration configuration = new KlvProcessor.Configuration();
+
+        klvProcessor.process(Collections.singletonMap(stangField, klvHandler),
+                metacard,
+                configuration);
+
+        ArgumentCaptor<Attribute> argumentCaptor = ArgumentCaptor.forClass(Attribute.class);
+
+        verify(metacard).setAttribute(argumentCaptor.capture());
+
+        return argumentCaptor;
+    }
+
+    /**
+     * value should be between -180 and 180
+     *
+     * @param name  name of the klv data element
+     * @param value value of the klv data element
+     * @return klv data element
+     * @throws KlvDecodingException
+     */
+    public static KlvIntegerEncodedFloatingPoint createTestFloat(String name, double value)
+            throws KlvDecodingException {
+
+        long encodedMin = -180;
+        long encodedMax = 180;
+
+        double actualRange = encodedMax - encodedMin;
+
+        double scaledValue = (value - encodedMin) / actualRange;
+
+        long encodedRangeMin = ((long) Integer.MIN_VALUE) + 1;
+
+        long encodedRange = ((long) Integer.MAX_VALUE) - encodedRangeMin;
+
+        long encodedValue = (long) (scaledValue * encodedRange + encodedRangeMin);
+
+        byte byte1 = (byte) ((encodedValue & 0xFF000000) >> 24);
+        byte byte2 = (byte) ((encodedValue & 0xFF0000) >> 16);
+        byte byte3 = (byte) ((encodedValue & 0xFF00) >> 8);
+        byte byte4 = (byte) (encodedValue & 0xFF);
+
+        final byte[] klvBytes = {-8, 4, byte1, byte2, byte3, byte4};
+        final KlvInt klvInt = new KlvInt(new byte[] {-8}, name);
+        final KlvIntegerEncodedFloatingPoint sensorRelativeElevationAngle =
+                new KlvIntegerEncodedFloatingPoint(klvInt,
+                        // Short.MIN_VALUE is an "out of range" indicator, so it is not included in the range.
+                        Integer.MIN_VALUE + 1,
+                        Integer.MAX_VALUE,
+                        encodedMin,
+                        encodedMax);
+        final KlvContext decodedKlvContext = decodeKLV(Klv.KeyLength.OneByte,
+                Klv.LengthEncoding.OneByte,
+                sensorRelativeElevationAngle,
+                klvBytes);
+
+        return (KlvIntegerEncodedFloatingPoint) decodedKlvContext.getDataElementByName(name);
+    }
+
+    private static KlvContext decodeKLV(final Klv.KeyLength keyLength,
+            final Klv.LengthEncoding lengthEncoding, final KlvDataElement dataElement,
+            final byte[] encodedBytes) throws KlvDecodingException {
+        final KlvContext klvContext = new KlvContext(keyLength, lengthEncoding);
+        klvContext.addDataElement(dataElement);
+        return new KlvDecoder(klvContext).decode(encodedBytes);
+    }
+
+}

--- a/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestClassifyingCountryKlvProcessor.java
+++ b/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestClassifyingCountryKlvProcessor.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.connexta.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
+
+import ddf.catalog.data.Attribute;
+
+public class TestClassifyingCountryKlvProcessor {
+
+    @Test
+    public void test() {
+
+        String id1 = "ID1";
+        String id2 = "ID2";
+
+        ArgumentCaptor<Attribute> argumentCaptor =
+                KlvUtilities.testKlvProcessor(new ClassifyingCountryKlvProcessor(),
+                        Stanag4609TransportStreamParser.CLASSIFYING_COUNTRY,
+                        Arrays.asList(id1, id2, id1, id2));
+
+        assertThat(argumentCaptor.getValue()
+                .getName(), is(AttributeNameConstants.CLASSIFYING_COUNTRY));
+        assertThat(argumentCaptor.getValue()
+                .getValues(), hasSize(2));
+        assertThat(argumentCaptor.getValue()
+                .getValues()
+                .containsAll(Arrays.asList(id1, id2)), is(true));
+
+    }
+}

--- a/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestCopyPresentKlvProcessor.java
+++ b/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestCopyPresentKlvProcessor.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.Test;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardImpl;
+
+public class TestCopyPresentKlvProcessor {
+
+    @Test
+    public void testProcess() {
+
+        String name = "fieldName";
+        String value = "string";
+
+        CopyPresentKlvProcessor copyPresentKlvProcessor = new CopyPresentKlvProcessor();
+
+        Attribute attribute = new AttributeImpl(name, value);
+
+        KlvHandler klvHandler = mock(KlvHandler.class);
+
+        when(klvHandler.asAttribute()).thenReturn(Optional.of(attribute));
+
+        Map<String, KlvHandler> handlers = Collections.singletonMap("someStanagFieldName",
+                klvHandler);
+
+        MetacardImpl metacard = new MetacardImpl(BasicTypes.BASIC_METACARD);
+
+        KlvProcessor.Configuration klvConfiguration = new KlvProcessor.Configuration();
+
+        copyPresentKlvProcessor.process(handlers, metacard, klvConfiguration);
+
+        assertThat(metacard.getAttribute(name)
+                .getValue(), is(value));
+
+    }
+
+}

--- a/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestFrameCenterKlvProcessor.java
+++ b/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestFrameCenterKlvProcessor.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.connexta.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKTReader;
+import com.vividsolutions.jts.io.WKTWriter;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+
+public class TestFrameCenterKlvProcessor {
+
+    @Test
+    public void test() throws ParseException {
+        FrameCenterKlvProcessor frameCenterKlvProcessor = new FrameCenterKlvProcessor();
+
+        KlvHandler klvHandler = mock(KlvHandler.class);
+
+        Attribute attribute = mock(Attribute.class);
+
+        when(klvHandler.asAttribute()).thenReturn(Optional.of(attribute));
+
+        when(attribute.getValues()).thenReturn(Arrays.asList("POINT(0 0)",
+                "POINT(1 1)",
+                "POINT(2 2)"));
+
+        Map<String, KlvHandler> handlerMap = new HashMap<>();
+        handlerMap.put(Stanag4609TransportStreamParser.FRAME_CENTER_LATITUDE, klvHandler);
+        handlerMap.put(Stanag4609TransportStreamParser.FRAME_CENTER_LONGITUDE, klvHandler);
+
+        Metacard metacard = mock(Metacard.class);
+
+        KlvProcessor.Configuration configuration = new KlvProcessor.Configuration();
+
+        frameCenterKlvProcessor.process(handlerMap, metacard, configuration);
+
+        ArgumentCaptor<Attribute> argumentCaptor = ArgumentCaptor.forClass(Attribute.class);
+
+        verify(metacard).setAttribute(argumentCaptor.capture());
+
+        assertThat(argumentCaptor.getValue()
+                .getValue(), is(normalize("LINESTRING (0 0, 1 1, 2 2)")));
+
+    }
+
+    private String normalize(String wkt) throws ParseException {
+        return new WKTWriter().write(new WKTReader().read(wkt)
+                .norm());
+    }
+
+}

--- a/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestGeoBoxHandler.java
+++ b/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestGeoBoxHandler.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.codice.ddf.libs.klv.KlvDecodingException;
+import org.codice.ddf.libs.klv.data.numerical.KlvInt;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestGeoBoxHandler {
+
+    private static final String LAT1 = "lat1";
+
+    private static final String LON1 = "lon1";
+
+    private static final String LAT2 = "lat2";
+
+    private static final String LON2 = "lon2";
+
+    private static final String LAT3 = "lat3";
+
+    private static final String LON3 = "lon3";
+
+    private static final String LAT4 = "lat4";
+
+    private static final String LON4 = "lon4";
+
+    private GeoBoxHandler geoBoxHandler;
+
+    @Before
+    public void setup() {
+        geoBoxHandler = new GeoBoxHandler("attributeName",
+                LAT1,
+                LON1,
+                LAT2,
+                LON2,
+                LAT3,
+                LON3,
+                LAT4,
+                LON4);
+    }
+
+    @Test
+    public void testGetRawGeoData() {
+        geoBoxHandler.accept(LAT1, 10.0);
+        assertThat(geoBoxHandler.getRawGeoData()
+                .get(LAT1)
+                .get(0), closeTo(10.0, 0.01));
+    }
+
+    @Test
+    public void testGetLatitude1() {
+        assertThat(geoBoxHandler.getLatitude1(), is(LAT1));
+    }
+
+    @Test
+    public void testGetLongitude1() {
+        assertThat(geoBoxHandler.getLongitude1(), is(LON1));
+    }
+
+    @Test
+    public void testGetLatitude2() {
+        assertThat(geoBoxHandler.getLatitude2(), is(LAT2));
+    }
+
+    @Test
+    public void testGetLongitude2() {
+        assertThat(geoBoxHandler.getLongitude2(), is(LON2));
+    }
+
+    @Test
+    public void testGetLatitude3() {
+        assertThat(geoBoxHandler.getLatitude3(), is(LAT3));
+    }
+
+    @Test
+    public void testGetLongitude3() {
+        assertThat(geoBoxHandler.getLongitude3(), is(LON3));
+    }
+
+    @Test
+    public void testGetLatitude4() {
+        assertThat(geoBoxHandler.getLatitude4(), is(LAT4));
+    }
+
+    @Test
+    public void testGetLongitude4() {
+        assertThat(geoBoxHandler.getLongitude4(), is(LON4));
+    }
+
+    @Test
+    public void testEmpty() {
+        assertThat(geoBoxHandler.asAttribute()
+                .isPresent(), is(false));
+    }
+
+    @Test
+    public void testAcceptWrongType() {
+
+        KlvInt klvInt = mock(KlvInt.class);
+
+        geoBoxHandler.accept(klvInt);
+
+        assertThat(geoBoxHandler.asAttribute()
+                .isPresent(), is(false));
+
+    }
+
+    @Test
+    public void testAcceptData() throws KlvDecodingException {
+
+        geoBoxHandler.accept(KlvUtilities.createTestFloat(LAT1, 1));
+        geoBoxHandler.accept(KlvUtilities.createTestFloat(LON1, 2));
+        geoBoxHandler.accept(KlvUtilities.createTestFloat(LAT2, 3));
+        geoBoxHandler.accept(KlvUtilities.createTestFloat(LON2, 4));
+        geoBoxHandler.accept(KlvUtilities.createTestFloat(LAT3, 5));
+        geoBoxHandler.accept(KlvUtilities.createTestFloat(LON3, 6));
+        geoBoxHandler.accept(KlvUtilities.createTestFloat(LAT4, 7));
+        geoBoxHandler.accept(KlvUtilities.createTestFloat(LON4, 8));
+
+        assertThat(geoBoxHandler.asAttribute()
+                        .get()
+                        .getValue(),
+                is("POLYGON ((2.000000 1.000000, 4.000000 3.000000, 6.000000 5.000000, 8.000000 7.000000, 2.000000 1.000000))"));
+
+    }
+}

--- a/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestGeometryUtility.java
+++ b/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestGeometryUtility.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKTReader;
+import com.vividsolutions.jts.io.WKTWriter;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.impl.AttributeImpl;
+
+public class TestGeometryUtility {
+
+    private static final String FIELD = "field";
+
+    private WKTReader wktReader;
+
+    private WKTWriter wktWriter;
+
+    @Before
+    public void setup() {
+        wktReader = new WKTReader();
+        wktWriter = new WKTWriter();
+    }
+
+    @Test
+    public void testBasicUnion() throws ParseException {
+
+        Attribute attribute = new AttributeImpl(FIELD,
+                Arrays.asList("POLYGON (( 0 0, 10 0, 10 10, 0 10, 0 0))",
+                        "POLYGON (( 5 5, 15 5, 15 15, 5 15, 5 5))"));
+
+        Optional<String> optionalWkt = GeometryUtility.createUnionOfGeometryAttribute(wktReader,
+                wktWriter,
+                attribute);
+
+        Geometry actual = wktReader.read(optionalWkt.get())
+                .norm();
+
+        Geometry expected = wktReader.read(
+                "POLYGON (( 0 0, 10 0, 10 5, 15 5, 15 15, 5 15, 5 10, 0 10, 0 0 ))")
+                .norm();
+
+        assertThat(actual, is(expected));
+
+    }
+
+    @Test
+    public void testEmptyData() {
+
+        Attribute attribute = new AttributeImpl(FIELD, Collections.emptyList());
+
+        Optional<String> optionalWkt = GeometryUtility.createUnionOfGeometryAttribute(wktReader,
+                wktWriter,
+                attribute);
+
+        assertThat(optionalWkt.isPresent(), is(false));
+
+    }
+
+    @Test
+    public void testBadData() {
+        Attribute attribute = new AttributeImpl(FIELD,
+                Collections.singletonList("POLYGON (( x 0, 10 0, 10 10, 0 10, 0 0))"));
+
+        Optional<String> optionalWkt = GeometryUtility.createUnionOfGeometryAttribute(wktReader,
+                wktWriter,
+                attribute);
+
+        assertThat(optionalWkt.isPresent(), is(false));
+
+    }
+
+    @Test
+    public void testGoodDataFollowedByBadData() throws ParseException {
+
+        Attribute attribute = new AttributeImpl(FIELD,
+                Arrays.asList("POLYGON (( 0 0, 10 0, 10 10, 0 10, 0 0))",
+                        "POLYGON (( x 5, 15 5, 15 15, 5 15, 5 5))"));
+
+        Optional<String> optionalWkt = GeometryUtility.createUnionOfGeometryAttribute(wktReader,
+                wktWriter,
+                attribute);
+
+        Geometry actual = wktReader.read(optionalWkt.get())
+                .norm();
+
+        Geometry expected = wktReader.read("POLYGON (( 0 0, 10 0, 10 10, 0 10, 0 0))")
+                .norm();
+
+        assertThat(actual, is(expected));
+
+    }
+
+    @Test
+    public void testBadDataFollowedByGoodData() throws ParseException {
+
+        Attribute attribute = new AttributeImpl(FIELD,
+                Arrays.asList("POLYGON (( x 0, 10 0, 10 10, 0 10, 0 0))",
+                        "POLYGON (( 5 5, 15 5, 15 15, 5 15, 5 5))"));
+
+        Optional<String> optionalWkt = GeometryUtility.createUnionOfGeometryAttribute(wktReader,
+                wktWriter,
+                attribute);
+
+        Geometry actual = wktReader.read(optionalWkt.get())
+                .norm();
+
+        Geometry expected = wktReader.read("POLYGON (( 5 5, 15 5, 15 15, 5 15, 5 5))")
+                .norm();
+
+        assertThat(actual, is(expected));
+
+    }
+
+    @Test
+    public void testBadDataFollowedByBadData() throws ParseException {
+
+        Attribute attribute = new AttributeImpl(FIELD,
+                Arrays.asList("POLYGON (( x 0, 10 0, 10 10, 0 10, 0 0))",
+                        "POLYGON (( x 5, 15 5, 15 15, 5 15, 5 5))"));
+
+        Optional<String> optionalWkt = GeometryUtility.createUnionOfGeometryAttribute(wktReader,
+                wktWriter,
+                attribute);
+
+        assertThat(optionalWkt.isPresent(), is(false));
+
+    }
+
+}

--- a/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestImageSourceSensorKlvProcessor.java
+++ b/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestImageSourceSensorKlvProcessor.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.connexta.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
+
+import ddf.catalog.data.Attribute;
+
+public class TestImageSourceSensorKlvProcessor {
+
+    @Test
+    public void test() {
+
+        String id1 = "ID1";
+        String id2 = "ID2";
+
+        ArgumentCaptor<Attribute> argumentCaptor =
+                KlvUtilities.testKlvProcessor(new ImageSourceSensorKlvProcessor(),
+                        Stanag4609TransportStreamParser.IMAGE_SOURCE_SENSOR,
+                        Arrays.asList(id1, id2, id1, id2));
+
+        assertThat(argumentCaptor.getValue()
+                .getName(), is(AttributeNameConstants.IMAGE_SOURCE_SENSOR));
+        assertThat(argumentCaptor.getValue()
+                .getValues(), hasSize(2));
+        assertThat(argumentCaptor.getValue()
+                .getValues()
+                .containsAll(Arrays.asList(id1, id2)), is(true));
+
+    }
+
+}

--- a/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestKlvHandlerFactoryImpl.java
+++ b/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestKlvHandlerFactoryImpl.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+public class TestKlvHandlerFactoryImpl {
+
+    @Test
+    public void testCreateStanag4609Handlers() {
+
+        KlvHandlerFactoryImpl klvHandlerFactory = new KlvHandlerFactoryImpl();
+
+        Map<String, KlvHandler> handlers = klvHandlerFactory.createStanag4609Handlers();
+
+        assertThat(handlers.isEmpty(), is(false));
+
+    }
+
+}

--- a/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestLatitudeLongitudeHandler.java
+++ b/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestLatitudeLongitudeHandler.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.codice.ddf.libs.klv.KlvDecodingException;
+import org.codice.ddf.libs.klv.data.numerical.KlvInt;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestLatitudeLongitudeHandler {
+
+    private static final String LAT = "lat";
+
+    private static final String LON = "lon";
+
+    private LatitudeLongitudeHandler klvHandler;
+
+    @Before
+    public void setup() {
+        klvHandler = new LatitudeLongitudeHandler("field", LAT, LON);
+    }
+
+    @Test
+    public void testGetLongitudeFieldName() {
+        assertThat(klvHandler.getLongitudeFieldName(), is(LON));
+    }
+
+    @Test
+    public void testGetLatitudeFieldName() {
+        assertThat(klvHandler.getLatitudeFieldName(), is(LAT));
+    }
+
+    @Test
+    public void testGetRawGeoData() throws KlvDecodingException {
+        klvHandler.accept(KlvUtilities.createTestFloat(LAT, 10.0));
+        assertThat(klvHandler.getRawGeoData()
+                .get(LAT)
+                .get(0), closeTo(10.0, 0.01));
+    }
+
+    @Test
+    public void testEmpty() {
+        assertThat(klvHandler.asAttribute()
+                .isPresent(), is(false));
+    }
+
+    @Test
+    public void testAcceptingData() throws KlvDecodingException {
+
+        double expectedLatitude = 33;
+        double expectedLongitude = -112;
+
+        klvHandler.accept(KlvUtilities.createTestFloat(LAT, expectedLatitude));
+        klvHandler.accept(KlvUtilities.createTestFloat(LON, expectedLongitude));
+
+        String r = (String) klvHandler.asAttribute()
+                .get()
+                .getValue();
+
+        Pattern p = Pattern.compile("POINT \\(([^ ]+) ([^)]+)\\)");
+
+        Matcher m = p.matcher(r);
+
+        assertThat(m.matches(), is(true));
+        assertThat(m.groupCount(), is(2));
+
+        assertThat(Double.parseDouble(m.group(1)), is(closeTo(expectedLongitude, 0.01)));
+        assertThat(Double.parseDouble(m.group(2)), is(closeTo(expectedLatitude, 0.01)));
+
+    }
+
+    @Test
+    public void testAcceptWrongType() {
+
+        KlvInt klvInt = mock(KlvInt.class);
+
+        klvHandler.accept(klvInt);
+
+        assertThat(klvHandler.asAttribute()
+                .isPresent(), is(false));
+
+    }
+}

--- a/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestListKlvProcessor.java
+++ b/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestListKlvProcessor.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+import ddf.catalog.data.impl.MetacardImpl;
+
+public class TestListKlvProcessor {
+
+    @Test
+    public void testProcess() {
+
+        AtomicBoolean atomicBoolean = new AtomicBoolean(false);
+
+        KlvProcessor klvProcessor = (handlers, metacard, configuration) -> atomicBoolean.set(true);
+
+        ListKlvProcessor listKlvProcessor = new ListKlvProcessor(Collections.singletonList(
+                klvProcessor));
+
+        listKlvProcessor.process(Collections.emptyMap(),
+                mock(MetacardImpl.class),
+                new KlvProcessor.Configuration());
+
+        assertThat(atomicBoolean.get(), is(true));
+
+    }
+
+}

--- a/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestListOfBasicKlvDataTypesHandler.java
+++ b/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestListOfBasicKlvDataTypesHandler.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.codice.ddf.libs.klv.KlvDecodingException;
+import org.codice.ddf.libs.klv.data.numerical.KlvInt;
+import org.codice.ddf.libs.klv.data.numerical.KlvIntegerEncodedFloatingPoint;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestListOfBasicKlvDataTypesHandler {
+
+    private KlvHandler handler;
+
+    @Before
+    public void setup() {
+        handler = new ListOfBasicKlvDataTypesHandler<>("field",
+                KlvIntegerEncodedFloatingPoint.class);
+    }
+
+    @Test
+    public void testEmpty() {
+        assertThat(handler.asAttribute()
+                .isPresent(), is(false));
+    }
+
+    @Test
+    public void testAcceptWrongType() {
+
+        KlvInt klvInt = mock(KlvInt.class);
+
+        handler.accept(klvInt);
+
+        assertThat(handler.asAttribute()
+                .isPresent(), is(false));
+
+    }
+
+    @Test
+    public void testAcceptingData() throws KlvDecodingException {
+
+        double expected = 100;
+
+        handler.accept(KlvUtilities.createTestFloat("a", expected));
+
+        assertThat(handler.asAttribute()
+                .isPresent(), is(true));
+
+        assertThat(((Double) handler.asAttribute()
+                .get()
+                .getValue()), is(closeTo(expected, 0.001)));
+
+    }
+
+}

--- a/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestListOfDatesHandler.java
+++ b/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestListOfDatesHandler.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import org.codice.ddf.libs.klv.data.numerical.KlvInt;
+import org.codice.ddf.libs.klv.data.numerical.KlvLong;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestListOfDatesHandler {
+
+    private KlvHandler klvHandler;
+
+    @Before
+    public void setup() {
+        klvHandler = new ListOfDatesHandler("field");
+    }
+
+    @Test
+    public void testEmpty() {
+        assertThat(klvHandler.asAttribute()
+                .isPresent(), is(false));
+    }
+
+    @Test
+    public void testAcceptingData() {
+        Date testDate = new Date();
+
+        KlvLong klvLong = mock(KlvLong.class);
+        when(klvLong.getValue()).thenReturn(TimeUnit.MILLISECONDS.toMicros(testDate.getTime()));
+
+        klvHandler.accept(klvLong);
+
+        assertThat(klvHandler.asAttribute()
+                .isPresent(), is(true));
+
+        assertThat(klvHandler.asAttribute()
+                .get()
+                .getValue(), is(testDate));
+    }
+
+    @Test
+    public void testAcceptWrongType() {
+
+        KlvInt klvInt = mock(KlvInt.class);
+
+        klvHandler.accept(klvInt);
+
+        assertThat(klvHandler.asAttribute()
+                .isPresent(), is(false));
+
+    }
+}

--- a/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestLocationKlvProcessor.java
+++ b/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestLocationKlvProcessor.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardImpl;
+
+public class TestLocationKlvProcessor {
+
+    private String wkt;
+
+    private LocationKlvProcessor locationKlvProcessor;
+
+    private GeoBoxHandler klvHandler;
+
+    private Metacard metacard;
+
+    private KlvProcessor.Configuration klvConfiguration;
+
+    private Map<String, KlvHandler> handlers;
+
+    @Before
+    public void setup() {
+        wkt = "POLYGON ((0 0, 5 0, 5 5, 0 5, 0 0))";
+        locationKlvProcessor = new LocationKlvProcessor();
+        klvHandler = mock(GeoBoxHandler.class);
+        Attribute attribute = mock(Attribute.class);
+        when(attribute.getValues()).thenReturn(Collections.singletonList(wkt));
+        when(klvHandler.asAttribute()).thenReturn(Optional.of(attribute));
+        when(klvHandler.getAttributeName()).thenReturn(AttributeNameConstants.CORNER);
+        metacard = new MetacardImpl(BasicTypes.BASIC_METACARD);
+        klvConfiguration = new KlvProcessor.Configuration();
+        handlers = Collections.singletonMap(AttributeNameConstants.CORNER, klvHandler);
+    }
+
+    @Test
+    public void testProcess() {
+
+        klvConfiguration.set(KlvProcessor.Configuration.SUBSAMPLE_COUNT, 50);
+
+        locationKlvProcessor.process(handlers, metacard, klvConfiguration);
+
+        assertThat(metacard.getLocation(), is(wkt));
+
+    }
+
+    /**
+     * Test where the subsample count is missing from the configuration.
+     */
+    @Test
+    public void testMissingConfiguration() {
+
+        locationKlvProcessor.process(handlers, metacard, klvConfiguration);
+
+        assertThat(metacard.getLocation(), nullValue());
+
+    }
+
+    /**
+     * Test a subsample count that is below the minimum required by LocationKlvProcessor.
+     */
+    @Test
+    public void testBadConfiguration() {
+
+        klvConfiguration.set(KlvProcessor.Configuration.SUBSAMPLE_COUNT,
+                LocationKlvProcessor.MIN_SUBSAMPLE_COUNT - 1);
+
+        locationKlvProcessor.process(handlers, metacard, klvConfiguration);
+
+        assertThat(metacard.getLocation(), nullValue());
+
+    }
+
+    /**
+     * This test iterates through a wide range of subsample inputs to make sure they all reduce to the
+     * subsample target and that there are no rounding issues.
+     */
+    @Test
+    public void testSubsample() {
+
+        int subsampleCount = 50;
+
+        String lat1 = "lat1";
+        String lon1 = "lon1";
+        String lat2 = "lat2";
+        String lon2 = "lon2";
+        String lat3 = "lat3";
+        String lon3 = "lon3";
+        String lat4 = "lat4";
+        String lon4 = "lon4";
+
+        int start = subsampleCount + 1;
+        int end = subsampleCount * 10;
+
+        when(klvHandler.getLatitude1()).thenReturn(lat1);
+        when(klvHandler.getLongitude1()).thenReturn(lon1);
+        when(klvHandler.getLatitude2()).thenReturn(lat2);
+        when(klvHandler.getLongitude2()).thenReturn(lon2);
+        when(klvHandler.getLatitude3()).thenReturn(lat3);
+        when(klvHandler.getLongitude3()).thenReturn(lon3);
+        when(klvHandler.getLatitude4()).thenReturn(lat4);
+        when(klvHandler.getLongitude4()).thenReturn(lon4);
+
+        for (int originalSize = start; originalSize < end; originalSize++) {
+
+            Map<String, List<Double>> rawData = new HashMap<>();
+
+            when(klvHandler.getRawGeoData()).thenReturn(rawData);
+
+            rawData.put(lat1, new ArrayList<>());
+            rawData.put(lon1, new ArrayList<>());
+            rawData.put(lat2, new ArrayList<>());
+            rawData.put(lon2, new ArrayList<>());
+            rawData.put(lat3, new ArrayList<>());
+            rawData.put(lon3, new ArrayList<>());
+            rawData.put(lat4, new ArrayList<>());
+            rawData.put(lon4, new ArrayList<>());
+
+            for (int i = 0; i < originalSize; i++) {
+                add(rawData, lat1, i);
+                add(rawData, lon1, i);
+                add(rawData, lat2, i);
+                add(rawData, lon2, i);
+                add(rawData, lat3, i);
+                add(rawData, lon3, i);
+                add(rawData, lat4, i);
+                add(rawData, lon4, i);
+            }
+
+            GeoBoxHandler subsampledGeoBoxHandler = locationKlvProcessor.subsample(klvHandler,
+                    subsampleCount);
+
+            Map<String, List<Double>> newRawData = subsampledGeoBoxHandler.getRawGeoData();
+
+            assertThatCount(newRawData, lat1, subsampleCount);
+            assertThatCount(newRawData, lon1, subsampleCount);
+            assertThatCount(newRawData, lat2, subsampleCount);
+            assertThatCount(newRawData, lon2, subsampleCount);
+            assertThatCount(newRawData, lat3, subsampleCount);
+            assertThatCount(newRawData, lon3, subsampleCount);
+            assertThatCount(newRawData, lat4, subsampleCount);
+            assertThatCount(newRawData, lon4, subsampleCount);
+
+        }
+    }
+
+    private void add(Map<String, List<Double>> rawData, String name, int value) {
+        rawData.get(name)
+                .add((double) value);
+    }
+
+    private void assertThatCount(Map<String, List<Double>> rawData, String name, int count) {
+        assertThat(rawData.get(name), hasSize(count));
+    }
+}

--- a/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestLoggingKlvHandler.java
+++ b/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestLoggingKlvHandler.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import org.codice.ddf.libs.klv.KlvDecodingException;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestLoggingKlvHandler {
+
+    private LoggingKlvHandler loggingKlvHandler;
+
+    @Before
+    public void setup() {
+        loggingKlvHandler = new LoggingKlvHandler();
+    }
+
+    @Test
+    public void testAccept() throws KlvDecodingException {
+
+        loggingKlvHandler.accept(KlvUtilities.createTestFloat("name", 1));
+
+        assertThat(loggingKlvHandler.asAttribute()
+                .isPresent(), is(false));
+
+    }
+
+    /**
+     * The LoggingKlvHandler always return null for the attribute name.
+     */
+    @Test
+    public void testAttributeName() {
+        assertThat(loggingKlvHandler.getAttributeName(), is(nullValue()));
+    }
+
+}

--- a/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestMissionIdKlvProcessor.java
+++ b/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestMissionIdKlvProcessor.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.connexta.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
+
+import ddf.catalog.data.Attribute;
+
+public class TestMissionIdKlvProcessor {
+
+    @Test
+    public void test() {
+
+        String id1 = "ID1";
+        String id2 = "ID2";
+
+        ArgumentCaptor<Attribute> argumentCaptor =
+                KlvUtilities.testKlvProcessor(new MissionIdKlvProcessor(),
+                        Stanag4609TransportStreamParser.MISSION_ID,
+                        Arrays.asList(id1, id2, id1, id2));
+
+        assertThat(argumentCaptor.getValue()
+                .getName(), is(AttributeNameConstants.MISSION_ID));
+        assertThat(argumentCaptor.getValue()
+                .getValues(), hasSize(2));
+        assertThat(argumentCaptor.getValue()
+                .getValues()
+                .containsAll(Arrays.asList(id1, id2)), is(true));
+
+    }
+
+}

--- a/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestObjectCountryCodeKlvProcessor.java
+++ b/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestObjectCountryCodeKlvProcessor.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.connexta.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
+
+import ddf.catalog.data.Attribute;
+
+public class TestObjectCountryCodeKlvProcessor {
+    @Test
+    public void test() {
+
+        String id1 = "ID1";
+        String id2 = "ID2";
+
+        ArgumentCaptor<Attribute> argumentCaptor =
+                KlvUtilities.testKlvProcessor(new ObjectCountryCodesKlvProcessor(),
+                        Stanag4609TransportStreamParser.OBJECT_COUNTRY_CODES,
+                        Arrays.asList(id1, id2, id1, id2));
+
+        assertThat(argumentCaptor.getValue()
+                .getName(), is(AttributeNameConstants.OBJECT_COUNTRY_CODES));
+        assertThat(argumentCaptor.getValue()
+                .getValues(), hasSize(2));
+        assertThat(argumentCaptor.getValue()
+                .getValues()
+                .containsAll(Arrays.asList(id1, id2)), is(true));
+
+    }
+}

--- a/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestOffsetCenterPostProcessor.java
+++ b/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestOffsetCenterPostProcessor.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.mockito.Matchers.doubleThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.codice.ddf.libs.klv.KlvDataElement;
+import org.codice.ddf.libs.klv.KlvDecodingException;
+import org.junit.Test;
+
+import com.connexta.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
+
+public class TestOffsetCenterPostProcessor {
+
+    @Test
+    public void test() throws KlvDecodingException {
+
+        OffsetCenterPostProcessor offsetCenterPostProcessor = new OffsetCenterPostProcessor();
+
+        Map<String, KlvHandler> handlers = new HashMap<>();
+
+        GeoBoxHandler cornerHandler = mock(GeoBoxHandler.class);
+        GeoBoxHandler offsetHandler = mock(GeoBoxHandler.class);
+        LatitudeLongitudeHandler centerHandler = mock(LatitudeLongitudeHandler.class);
+
+        handlers.put(Stanag4609TransportStreamParser.CORNER_LATITUDE_1, cornerHandler);
+        handlers.put(Stanag4609TransportStreamParser.CORNER_LATITUDE_2, cornerHandler);
+        handlers.put(Stanag4609TransportStreamParser.CORNER_LATITUDE_3, cornerHandler);
+        handlers.put(Stanag4609TransportStreamParser.CORNER_LATITUDE_4, cornerHandler);
+        handlers.put(Stanag4609TransportStreamParser.CORNER_LONGITUDE_1, cornerHandler);
+        handlers.put(Stanag4609TransportStreamParser.CORNER_LONGITUDE_2, cornerHandler);
+        handlers.put(Stanag4609TransportStreamParser.CORNER_LONGITUDE_3, cornerHandler);
+        handlers.put(Stanag4609TransportStreamParser.CORNER_LONGITUDE_4, cornerHandler);
+
+        handlers.put(Stanag4609TransportStreamParser.OFFSET_CORNER_LATITUDE_1, offsetHandler);
+        handlers.put(Stanag4609TransportStreamParser.OFFSET_CORNER_LATITUDE_2, offsetHandler);
+        handlers.put(Stanag4609TransportStreamParser.OFFSET_CORNER_LATITUDE_3, offsetHandler);
+        handlers.put(Stanag4609TransportStreamParser.OFFSET_CORNER_LATITUDE_4, offsetHandler);
+        handlers.put(Stanag4609TransportStreamParser.OFFSET_CORNER_LONGITUDE_1, offsetHandler);
+        handlers.put(Stanag4609TransportStreamParser.OFFSET_CORNER_LONGITUDE_2, offsetHandler);
+        handlers.put(Stanag4609TransportStreamParser.OFFSET_CORNER_LONGITUDE_3, offsetHandler);
+        handlers.put(Stanag4609TransportStreamParser.OFFSET_CORNER_LONGITUDE_4, offsetHandler);
+
+        handlers.put(Stanag4609TransportStreamParser.FRAME_CENTER_LATITUDE, centerHandler);
+        handlers.put(Stanag4609TransportStreamParser.FRAME_CENTER_LONGITUDE, centerHandler);
+
+        Map<String, KlvDataElement> dataElements = new HashMap<>();
+
+        double lat1 = 1;
+        double lat2 = 2;
+        double lat3 = 3;
+        double lat4 = 4;
+        double lon1 = 5;
+        double lon2 = 6;
+        double lon3 = 7;
+        double lon4 = 8;
+
+        double lat = 30;
+        double lon = 50;
+
+        add(dataElements, Stanag4609TransportStreamParser.OFFSET_CORNER_LATITUDE_1, lat1);
+        add(dataElements, Stanag4609TransportStreamParser.OFFSET_CORNER_LATITUDE_2, lat2);
+        add(dataElements, Stanag4609TransportStreamParser.OFFSET_CORNER_LATITUDE_3, lat3);
+        add(dataElements, Stanag4609TransportStreamParser.OFFSET_CORNER_LATITUDE_4, lat4);
+        add(dataElements, Stanag4609TransportStreamParser.OFFSET_CORNER_LONGITUDE_1, lon1);
+        add(dataElements, Stanag4609TransportStreamParser.OFFSET_CORNER_LONGITUDE_2, lon2);
+        add(dataElements, Stanag4609TransportStreamParser.OFFSET_CORNER_LONGITUDE_3, lon3);
+        add(dataElements, Stanag4609TransportStreamParser.OFFSET_CORNER_LONGITUDE_4, lon4);
+
+        add(dataElements, Stanag4609TransportStreamParser.FRAME_CENTER_LATITUDE, lat);
+        add(dataElements, Stanag4609TransportStreamParser.FRAME_CENTER_LONGITUDE, lon);
+
+        offsetCenterPostProcessor.postProcess(dataElements, handlers);
+
+        verifyThat(cornerHandler, Stanag4609TransportStreamParser.CORNER_LATITUDE_1, lat1 + lat);
+        verifyThat(cornerHandler, Stanag4609TransportStreamParser.CORNER_LATITUDE_2, lat2 + lat);
+        verifyThat(cornerHandler, Stanag4609TransportStreamParser.CORNER_LATITUDE_3, lat3 + lat);
+        verifyThat(cornerHandler, Stanag4609TransportStreamParser.CORNER_LATITUDE_4, lat4 + lat);
+        verifyThat(cornerHandler, Stanag4609TransportStreamParser.CORNER_LONGITUDE_1, lon1 + lon);
+        verifyThat(cornerHandler, Stanag4609TransportStreamParser.CORNER_LONGITUDE_2, lon2 + lon);
+        verifyThat(cornerHandler, Stanag4609TransportStreamParser.CORNER_LONGITUDE_3, lon3 + lon);
+        verifyThat(cornerHandler, Stanag4609TransportStreamParser.CORNER_LONGITUDE_4, lon4 + lon);
+
+    }
+
+    private void verifyThat(GeoBoxHandler cornerHandler, String name, double value) {
+        verify(cornerHandler).accept(eq(name), doubleThat(closeTo(value, 0.01)));
+    }
+
+    private void add(Map<String, KlvDataElement> dataElements, String name, double value)
+            throws KlvDecodingException {
+        dataElements.put(name, KlvUtilities.createTestFloat(name, value));
+    }
+
+}

--- a/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestPlatformDesignationKlvProcessor.java
+++ b/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestPlatformDesignationKlvProcessor.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.connexta.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
+
+import ddf.catalog.data.Attribute;
+
+public class TestPlatformDesignationKlvProcessor {
+
+    @Test
+    public void test() {
+
+        String id1 = "ID1";
+        String id2 = "ID2";
+
+        ArgumentCaptor<Attribute> argumentCaptor =
+                KlvUtilities.testKlvProcessor(new PlatformDesignationKlvProcessor(),
+                        Stanag4609TransportStreamParser.PLATFORM_DESIGNATION,
+                        Arrays.asList(id1, id2, id1, id2));
+
+        assertThat(argumentCaptor.getValue()
+                .getName(), is(AttributeNameConstants.PLATFORM_DESIGNATION));
+        assertThat(argumentCaptor.getValue()
+                .getValues(), hasSize(2));
+        assertThat(argumentCaptor.getValue()
+                .getValues()
+                .containsAll(Arrays.asList(id1, id2)), is(true));
+
+    }
+
+}

--- a/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestSecurityClassificationKlvProcessor.java
+++ b/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestSecurityClassificationKlvProcessor.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.connexta.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
+
+import ddf.catalog.data.Attribute;
+
+public class TestSecurityClassificationKlvProcessor {
+
+    @Test
+    public void test() {
+
+        Short id1 = 10;
+        Short id2 = 20;
+
+        ArgumentCaptor<Attribute> argumentCaptor =
+                KlvUtilities.testKlvProcessor(new SecurityClassificationKlvProcessor(),
+                        Stanag4609TransportStreamParser.SECURITY_CLASSIFICATION,
+                        Arrays.asList(id1, id2, id1, id2));
+
+        assertThat(argumentCaptor.getValue()
+                .getName(), is(AttributeNameConstants.SECURITY_CLASSIFICATION));
+        assertThat(argumentCaptor.getValue()
+                .getValues(), hasSize(2));
+        assertThat(argumentCaptor.getValue()
+                .getValues()
+                .containsAll(Arrays.asList(id1, id2)), is(true));
+
+    }
+
+}

--- a/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestSetDatesKlvProcessor.java
+++ b/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestSetDatesKlvProcessor.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.Test;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.impl.BasicTypes;
+import ddf.catalog.data.impl.MetacardImpl;
+
+public class TestSetDatesKlvProcessor {
+
+    @Test
+    public void testProcess() throws ParseException {
+
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+        Date firstDate = simpleDateFormat.parse("2016-04-01 02:00:00");
+        Date secondDate = simpleDateFormat.parse("2016-04-01 03:00:00");
+        Date thirdDate = simpleDateFormat.parse("2016-04-01 04:00:00");
+
+        Attribute attribute = mock(Attribute.class);
+        when(attribute.getValues()).thenReturn(Arrays.asList(firstDate, secondDate, thirdDate));
+        KlvHandler klvHandler = mock(KlvHandler.class);
+        when(klvHandler.asAttribute()).thenReturn(Optional.of(attribute));
+
+        Map<String, KlvHandler> handlers =
+                Collections.singletonMap(AttributeNameConstants.TIMESTAMP, klvHandler);
+
+        MetacardImpl metacard = new MetacardImpl(BasicTypes.BASIC_METACARD);
+
+        SetDatesKlvProcessor setDatesKlvProcessor = new SetDatesKlvProcessor();
+        setDatesKlvProcessor.process(handlers, metacard, new KlvProcessor.Configuration());
+
+        assertThat(metacard.getCreatedDate(), is(firstDate));
+
+        assertThat(metacard.getAttribute(AttributeNameConstants.TEMPORAL_START)
+                .getValue(), is(firstDate));
+        assertThat(metacard.getAttribute(AttributeNameConstants.TEMPORAL_END)
+                .getValue(), is(thirdDate));
+
+    }
+
+}

--- a/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestStanag4609ProcessorImpl.java
+++ b/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestStanag4609ProcessorImpl.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.codice.ddf.libs.klv.KlvContext;
+import org.codice.ddf.libs.klv.KlvDataElement;
+import org.codice.ddf.libs.klv.KlvDecodingException;
+import org.codice.ddf.libs.klv.data.Klv;
+import org.codice.ddf.libs.klv.data.numerical.KlvIntegerEncodedFloatingPoint;
+import org.codice.ddf.libs.klv.data.set.KlvLocalSet;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.connexta.alliance.libs.stanag4609.DecodedKLVMetadataPacket;
+
+public class TestStanag4609ProcessorImpl {
+
+    private static final String FIELD_NAME = "field";
+
+    private Stanag4609Processor stanag4609Processor;
+
+    private KlvHandler klvHandler;
+
+    private KlvHandler defaultKlvHandler;
+
+    private KlvIntegerEncodedFloatingPoint klvIntegerEncodedFloatingPoint;
+
+    private Map<String, KlvDataElement> dataElements;
+
+    @Before
+    public void setup() throws KlvDecodingException {
+        stanag4609Processor = new Stanag4609ProcessorImpl(mock(PostProcessor.class));
+        klvHandler = mock(KlvHandler.class);
+        defaultKlvHandler = mock(KlvHandler.class);
+        klvIntegerEncodedFloatingPoint = KlvUtilities.createTestFloat(FIELD_NAME, 100);
+        dataElements = new HashMap<>();
+    }
+
+    @Test
+    public void testRegularHandlerForCallDataElementHandlers() throws KlvDecodingException {
+
+        stanag4609Processor.callDataElementHandlers(Collections.singletonMap(FIELD_NAME,
+                klvHandler), defaultKlvHandler, klvIntegerEncodedFloatingPoint, dataElements);
+
+        verify(klvHandler, atLeastOnce()).accept(klvIntegerEncodedFloatingPoint);
+
+    }
+
+    @Test
+    public void testDefaultHandlerForCallDataElementHandlers() throws KlvDecodingException {
+
+        KlvIntegerEncodedFloatingPoint otherKlvIntegerEncodedFloatingPoint =
+                KlvUtilities.createTestFloat("someOtherField", 100);
+
+        stanag4609Processor.callDataElementHandlers(Collections.singletonMap(FIELD_NAME,
+                klvHandler), defaultKlvHandler, otherKlvIntegerEncodedFloatingPoint, dataElements);
+
+        verify(defaultKlvHandler, atLeastOnce()).accept(otherKlvIntegerEncodedFloatingPoint);
+
+    }
+
+    @Test
+    public void testHandleWithKlvContext() throws KlvDecodingException {
+
+        KlvContext klvContext = new KlvContext(Klv.KeyLength.OneByte,
+                Klv.LengthEncoding.OneByte,
+                Collections.singleton(klvIntegerEncodedFloatingPoint));
+
+        stanag4609Processor.handle(Collections.singletonMap(FIELD_NAME, klvHandler),
+                defaultKlvHandler,
+                klvContext,
+                dataElements);
+
+        verify(klvHandler, atLeastOnce()).accept(klvIntegerEncodedFloatingPoint);
+
+    }
+
+    @Test
+    public void testHandleWithKlvLocalSet() throws KlvDecodingException {
+
+        KlvContext klvContext = new KlvContext(Klv.KeyLength.OneByte,
+                Klv.LengthEncoding.OneByte,
+                Collections.singleton(klvIntegerEncodedFloatingPoint));
+
+        KlvLocalSet klvLocalSet = mock(KlvLocalSet.class);
+        when(klvLocalSet.getValue()).thenReturn(klvContext);
+
+        stanag4609Processor.handle(Collections.singletonMap(FIELD_NAME, klvHandler),
+                defaultKlvHandler,
+                klvLocalSet,
+                dataElements);
+
+        verify(klvHandler, atLeastOnce()).accept(klvIntegerEncodedFloatingPoint);
+
+    }
+
+    @Test
+    public void testHandleWithKlvDataElement() throws KlvDecodingException {
+
+        stanag4609Processor.handle(Collections.singletonMap(FIELD_NAME, klvHandler),
+                defaultKlvHandler,
+                klvIntegerEncodedFloatingPoint,
+                dataElements);
+
+        verify(klvHandler, atLeastOnce()).accept(klvIntegerEncodedFloatingPoint);
+
+    }
+
+    @Test
+    public void testHandleWithStanagMetadata() throws KlvDecodingException {
+
+        DecodedKLVMetadataPacket p2 = mock(DecodedKLVMetadataPacket.class);
+        when(p2.getDecodedKLV()).thenReturn(new KlvContext(Klv.KeyLength.OneByte,
+                Klv.LengthEncoding.OneByte,
+                Collections.singleton(klvIntegerEncodedFloatingPoint)));
+
+        Map<String, KlvHandler> handlers = Collections.singletonMap(FIELD_NAME, klvHandler);
+        Map<Integer, List<DecodedKLVMetadataPacket>> stanag = Collections.singletonMap(1,
+                Collections.singletonList(p2));
+
+        stanag4609Processor.handle(handlers, defaultKlvHandler, stanag);
+
+        verify(klvHandler, atLeastOnce()).accept(klvIntegerEncodedFloatingPoint);
+
+    }
+
+}

--- a/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestStanagParserFactoryImpl.java
+++ b/libs/klv/src/test/java/com/connexta/alliance/libs/klv/TestStanagParserFactoryImpl.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.klv;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+
+import com.google.common.io.ByteSource;
+
+public class TestStanagParserFactoryImpl {
+
+    @Test
+    public void testCreateParser() {
+
+        StanagParserFactoryImpl stanagParserFactory = new StanagParserFactoryImpl();
+
+        assertThat(stanagParserFactory.createParser(mock(ByteSource.class)), notNullValue());
+
+    }
+
+}

--- a/libs/pom.xml
+++ b/libs/pom.xml
@@ -29,6 +29,7 @@
 
     <modules>
         <module>stanag4609</module>
+        <module>klv</module>
     </modules>
 
     <build>

--- a/libs/stanag4609/src/main/java/com/connexta/alliance/libs/stanag4609/Stanag4609TransportStreamParser.java
+++ b/libs/stanag4609/src/main/java/com/connexta/alliance/libs/stanag4609/Stanag4609TransportStreamParser.java
@@ -283,11 +283,11 @@ public class Stanag4609TransportStreamParser {
                 SECURITY_CLASSIFICATION));
         securityLocalSetContext.addDataElement(new KlvUnsignedByte(new byte[] {2},
                 CLASSIFYING_COUNTRY_CODING_METHOD));
-        securityLocalSetContext.addDataElement(new KlvUnsignedByte(new byte[] {3},
+        securityLocalSetContext.addDataElement(new KlvString(new byte[] {3},
                 CLASSIFYING_COUNTRY));
         securityLocalSetContext.addDataElement(new KlvUnsignedByte(new byte[] {12},
                 OBJECT_COUNTRY_CODING_METHOD));
-        securityLocalSetContext.addDataElement(new KlvUnsignedByte(new byte[] {13},
+        securityLocalSetContext.addDataElement(new KlvString(new byte[] {13},
                 OBJECT_COUNTRY_CODES));
 
         localSetContext.addDataElement(new KlvLocalSet(new byte[] {48},

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,8 @@
         <slf4j.version>1.7.12</slf4j.version>
         <maven.javadoc.plugin.version>2.7</maven.javadoc.plugin.version>
         <maven.release.plugin.version>2.5.1</maven.release.plugin.version>
+        <jcodec.version>0.2.0_1</jcodec.version>
+        <mpegts-streamer.version>0.1.0_1</mpegts-streamer.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
#### What does this PR do?

Add MPEGTS input transformer that extracts KLV metadata from the transport stream and adds it the metacard.

#### Who is reviewing it?
@rzwiefel @jrnorth @bdeining  @jlcsmith @beyelerb 

#### How should this be tested?
1) Use a DDF with the new metacard validation (latest 2.9.0-SNAPSHOT)
2) Build alliance-mpegts-transformer and alliance-video-app
3) copy alliance-video-app-0.1-SNAPSHOT.kar into ddf-2.9.0-SNAPSHOT/deploy
4) ingest FFMPEG sample data https://samples.ffmpeg.org/MPEG2/mpegts-klv/Night%20Flight%20IR.mpg (but rename file to .ts extension)
5) search for video file, confirm that the content type is video/mp2t and there is a metadata field called "Image Source Sensor". The value should be "IR". 

#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
