### PR TITLE
CAL-30 Moved NITF Mime Type Configuration from platform-app  to imaging-app

### DIFF
--- a/catalog/imaging/catalog-imaging-app/pom.xml
+++ b/catalog/imaging/catalog-imaging-app/pom.xml
@@ -80,6 +80,22 @@
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>attach-configs</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>src/main/resources/DDF_Custom_Mime_Type_Resolver.nitf.config</file>
+                                    <type>config</type>
+                                    <classifier>nitf</classifier>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>attach-artifacts</id>
                         <phase>package</phase>
                         <inherited>false</inherited>

--- a/catalog/imaging/catalog-imaging-app/src/main/resources/DDF_Custom_Mime_Type_Resolver.nitf.config
+++ b/catalog/imaging/catalog-imaging-app/src/main/resources/DDF_Custom_Mime_Type_Resolver.nitf.config
@@ -1,0 +1,4 @@
+customMimeTypes=["nitf\=image/nitf","ntf\=image/nitf","nsf\=image/nitf","nsif\=image/nitf"]
+name="NITF\ Content\ Resolver"
+priority=I"10"
+service.factoryPid="DDF_Custom_Mime_Type_Resolver"

--- a/catalog/imaging/catalog-imaging-app/src/main/resources/features.xml
+++ b/catalog/imaging/catalog-imaging-app/src/main/resources/features.xml
@@ -20,5 +20,6 @@
              description="The Alliance Imaging Application provides support for ingesting and searching for NITF products.  ::Alliance Imaging">
         <feature prerequisite="true">catalog-app</feature>
         <bundle>mvn:com.connexta.alliance.imaging/alliance-imaging-transformer/${project.version}</bundle>
+        <configfile finalname="/etc/DDF_Custom_Mime_Type_Resolver.nitf.config">mvn:com.connexta.alliance.imaging/alliance-imaging-app/${project.version}/config/nitf</configfile>
     </feature>
 </features>

--- a/support/support-checkstyle/pom.xml
+++ b/support/support-checkstyle/pom.xml
@@ -23,7 +23,7 @@
 
 	<groupId>com.connexta.alliance</groupId>
 	<artifactId>support-checkstyle</artifactId>
-	<name>Alliance Support Checkstyle</name>
+	<name>Alliance :: Support :: Checkstyle</name>
 	<description>Alliance checkstyle contains file for checking builds</description>
 
 </project>


### PR DESCRIPTION
#### What does this PR do?
This PR adds the NITF Custom Mime Types from DDF to Alliance
#### Who is reviewing it?
@jlcsmith 
@kcwire 
@dcruver 
#### How should this be tested?
Build Alliance and Observe the NITF Custom Mime Type
#### Any background context you want to provide?
Since the NITF Input transformer has been moved to Alliance, there is no longer the need for this configuration in DDF.
#### What are the relevant tickets?
https://codice.atlassian.net/browse/CAL-30
https://codice.atlassian.net/browse/DDF-2038
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

…