### PR TITLE
CAL-32 Add overview image to metacard

### DIFF
--- a/catalog/imaging/catalog-imaging-transformer/src/main/java/com/connexta/alliance/transformer/nitf/NitfPreStoragePlugin.java
+++ b/catalog/imaging/catalog-imaging-transformer/src/main/java/com/connexta/alliance/transformer/nitf/NitfPreStoragePlugin.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.transformer.nitf;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.List;
+
+import javax.imageio.ImageIO;
+import javax.imageio.stream.ImageInputStream;
+import javax.imageio.stream.MemoryCacheImageInputStream;
+
+import org.apache.commons.io.FilenameUtils;
+import org.codice.imaging.nitf.core.AllDataExtractionParseStrategy;
+import org.codice.imaging.nitf.core.NitfFileParser;
+import org.codice.imaging.nitf.core.common.NitfInputStreamReader;
+import org.codice.imaging.nitf.core.common.NitfReader;
+import org.codice.imaging.nitf.core.image.NitfImageSegmentHeader;
+import org.codice.imaging.nitf.render.NitfRenderer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.io.ByteSource;
+
+import ddf.catalog.content.data.ContentItem;
+import ddf.catalog.content.data.impl.ContentItemImpl;
+import ddf.catalog.content.operation.CreateStorageRequest;
+import ddf.catalog.content.operation.UpdateStorageRequest;
+import ddf.catalog.content.plugin.PreCreateStoragePlugin;
+import ddf.catalog.content.plugin.PreUpdateStoragePlugin;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.plugin.PluginExecutionException;
+import net.coobird.thumbnailator.Thumbnails;
+
+/**
+ * This pre-storage plugin creates and stores the NITF thumbnail and NITF overview images.  The
+ * thumbnail is stored with the Metacard while the overview is stored in the content store.
+ */
+public class NitfPreStoragePlugin implements PreCreateStoragePlugin, PreUpdateStoragePlugin {
+
+    private static final String IMAGE_JPEG = "image/jpeg";
+
+    private static final int THUMBNAIL_WIDTH = 200;
+
+    private static final int THUMBNAIL_HEIGHT = 200;
+
+    private static final String JPG = "jpg";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NitfPreStoragePlugin.class);
+
+    private static final String OVERVIEW = "overview";
+
+    private static final String OVERVIEW_FILENAME_PATTERN = "%s-%s.%s";
+
+    @Override
+    public CreateStorageRequest process(CreateStorageRequest createStorageRequest)
+            throws PluginExecutionException {
+        if (createStorageRequest == null) {
+            throw new PluginExecutionException(
+                    "process(): argument 'createStorageRequest' may not be null.");
+        }
+
+        process(createStorageRequest.getContentItems());
+        return createStorageRequest;
+    }
+
+    @Override
+    public UpdateStorageRequest process(UpdateStorageRequest updateStorageRequest)
+            throws PluginExecutionException {
+        if (updateStorageRequest == null) {
+            throw new PluginExecutionException(
+                    "process(): argument 'updateStorageRequest' may not be null.");
+        }
+
+        process(updateStorageRequest.getContentItems());
+        return updateStorageRequest;
+    }
+
+    private void process(List<ContentItem> contentItems) {
+        ContentItem contentItem = contentItems.get(0);
+        Metacard metacard = contentItem.getMetacard();
+
+        try {
+            BufferedImage renderedImage = renderImage(contentItem);
+
+            if (renderedImage != null) {
+                addThumbnailToMetacard(metacard, renderedImage);
+                ContentItem overviewContentItem = createOverview(contentItem.getId(), renderedImage,
+                        metacard);
+
+                if (overviewContentItem != null) {
+                    contentItems.add(overviewContentItem);
+                }
+            }
+        } catch (IOException | ParseException e) {
+            LOGGER.warn(e.getMessage(), e);
+        }
+    }
+
+    private BufferedImage renderImage(ContentItem contentItem) throws IOException, ParseException {
+        NitfReader reader = new NitfInputStreamReader(contentItem.getInputStream());
+        AllDataExtractionParseStrategy parsingStrategy = new AllDataExtractionParseStrategy();
+        NitfFileParser.parse(reader, parsingStrategy);
+
+        if (parsingStrategy.getImageSegmentData().size() == 0) {
+            return null;
+        }
+
+        NitfImageSegmentHeader header = parsingStrategy.getImageSegmentHeaders().get(0);
+        byte[] image = parsingStrategy.getImageSegmentData().get(0);
+
+        NitfRenderer renderer = new NitfRenderer();
+        ImageInputStream inputStream = new MemoryCacheImageInputStream(
+                new ByteArrayInputStream(image));
+        BufferedImage bufferedImage = renderer.render(header, inputStream);
+        return bufferedImage;
+    }
+
+    private void addThumbnailToMetacard(Metacard metacard, BufferedImage bufferedImage) {
+        try {
+            byte[] thumbnailImage = scaleImage(bufferedImage, THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT);
+
+            if (thumbnailImage.length > 0) {
+                metacard.setAttribute(new AttributeImpl(Metacard.THUMBNAIL, thumbnailImage));
+            }
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage(), e);
+        }
+    }
+
+    private ContentItem createOverview(String id, BufferedImage image, Metacard metacard) {
+        try {
+            byte[] overviewBytes = scaleImage(image, image.getWidth(), image.getHeight());
+            ByteSource source = ByteSource.wrap(overviewBytes);
+            ContentItem contentItem = new ContentItemImpl(id, OVERVIEW,
+                    source, IMAGE_JPEG, buildOverviewTitle(metacard.getTitle()),
+                    overviewBytes.length, metacard);
+
+            metacard.setAttribute(new AttributeImpl(Metacard.DERIVED_RESOURCE_URI,
+                    contentItem.getUri()));
+
+            return contentItem;
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage(), e);
+        }
+
+        return null;
+    }
+
+    private String buildOverviewTitle(String title) {
+        String rootFileName = FilenameUtils.getBaseName(title);
+        String overviewFileName = String.format(OVERVIEW_FILENAME_PATTERN, OVERVIEW, rootFileName, JPG);
+        return overviewFileName;
+    }
+
+    private byte[] scaleImage(final BufferedImage bufferedImage, int width, int height)
+            throws IOException {
+        BufferedImage thumbnail = Thumbnails.of(bufferedImage).size(width, height).outputFormat(JPG)
+                .imageType(BufferedImage.TYPE_3BYTE_BGR).asBufferedImage();
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ImageIO.write(thumbnail, JPG, outputStream);
+        outputStream.flush();
+        byte[] thumbnailBytes = outputStream.toByteArray();
+        outputStream.close();
+        return thumbnailBytes;
+    }
+}

--- a/catalog/imaging/catalog-imaging-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/imaging/catalog-imaging-transformer/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -20,6 +20,8 @@
         <property name="nitfMetacardType" ref="metacardType"/>
     </bean>
 
+    <bean id="plugin" class="com.connexta.alliance.transformer.nitf.NitfPreStoragePlugin"/>
+
     <service ref="transformer" interface="ddf.catalog.transform.InputTransformer">
         <service-properties>
             <entry key="id" value="nitf"/>
@@ -39,6 +41,12 @@
     <service ref="metacardType" interface="ddf.catalog.data.MetacardType">
         <service-properties>
             <entry key="name" value="nitf"/>
+        </service-properties>
+    </service>
+
+    <service ref="plugin" auto-export="interfaces">
+        <service-properties>
+            <entry key="name" value="nitf-prestorage-plugin"/>
         </service-properties>
     </service>
 </blueprint>

--- a/catalog/imaging/catalog-imaging-transformer/src/test/java/com/connexta/alliance/transformer/nitf/TestPreStoragePlugin.java
+++ b/catalog/imaging/catalog-imaging-transformer/src/test/java/com/connexta/alliance/transformer/nitf/TestPreStoragePlugin.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.transformer.nitf;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.content.data.ContentItem;
+import ddf.catalog.content.operation.CreateStorageRequest;
+import ddf.catalog.content.operation.UpdateStorageRequest;
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.federation.FederationException;
+import ddf.catalog.plugin.PluginExecutionException;
+import ddf.catalog.source.SourceUnavailableException;
+import ddf.catalog.source.UnsupportedQueryException;
+
+public class TestPreStoragePlugin {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestPreStoragePlugin.class);
+
+    private static final String GEO_NITF = "/i_3001a.ntf";
+
+    private NitfPreStoragePlugin nitfPreStoragePlugin = null;
+
+    private CreateStorageRequest createStorageRequest = null;
+
+    private UpdateStorageRequest updateStorageRequest = null;
+
+    private Metacard metacard = null;
+
+    private ContentItem contentItem = null;
+
+    private ArgumentCaptor<Attribute> attributeArgumentCaptor = null;
+
+    @Before
+    public void setUp()
+            throws UnsupportedQueryException, SourceUnavailableException, FederationException,
+            IOException {
+        nitfPreStoragePlugin = new NitfPreStoragePlugin();
+
+        this.createStorageRequest = mock(CreateStorageRequest.class);
+        this.updateStorageRequest = mock(UpdateStorageRequest.class);
+        this.metacard = mock(Metacard.class);
+        this.contentItem = mock(ContentItem.class);
+        this.attributeArgumentCaptor = ArgumentCaptor.forClass(Attribute.class);
+        List<ContentItem> contentItems = new ArrayList<ContentItem>();
+        contentItems.add(contentItem);
+
+        when(createStorageRequest.getContentItems()).thenReturn(contentItems);
+        when(updateStorageRequest.getContentItems()).thenReturn(contentItems);
+        when(contentItem.getMetacard()).thenReturn(metacard);
+        when(contentItem.getId()).thenReturn("101ABC");
+        when(contentItem.getInputStream()).thenReturn(getInputStream(GEO_NITF));
+    }
+
+    @Test(expected = PluginExecutionException.class)
+    public void testNullInputOnCreate() throws PluginExecutionException {
+        nitfPreStoragePlugin.process((CreateStorageRequest) null);
+    }
+
+    @Test(expected = PluginExecutionException.class)
+    public void testNullInputOnUpdate() throws PluginExecutionException {
+        nitfPreStoragePlugin.process((UpdateStorageRequest) null);
+        validate();
+    }
+
+    @Test
+    public void testCreateStorageRequest() throws PluginExecutionException {
+        nitfPreStoragePlugin.process(createStorageRequest);
+        validate();
+    }
+
+
+    @Test
+    public void testUpdateStorageRequest() throws PluginExecutionException {
+        nitfPreStoragePlugin.process(updateStorageRequest);
+        validate();
+    }
+
+    private void validate() {
+        verify(contentItem, times(1)).getId();
+        verify(metacard, times(2)).setAttribute(attributeArgumentCaptor.capture());
+        Attribute thumbnail = attributeArgumentCaptor.getAllValues().get(0);
+        Attribute overview = attributeArgumentCaptor.getAllValues().get(1);
+        assertThat(thumbnail.getName(), is("thumbnail"));
+        assertThat(thumbnail.getValue(), is(notNullValue()));
+        assertThat(overview.getName(), is("resource.dervied-resource-uri"));
+        assertThat(overview.getValue(), is(notNullValue()));
+    }
+
+    private InputStream getInputStream(String filename) {
+        assertNotNull("Test file missing", getClass().getResource(filename));
+        return getClass().getResourceAsStream(filename);
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
This change adds a pre-storage plugin, moves thumbnail creation there and adds the creation of an overview.

#### Who is reviewing it?
@bdeining (hero)
@kcwire 
@beyelerb 

#### How should this be tested?
1) install the alliance-imaging-app
2) ingest a NITF through the UI
3) search for the ingested NITF
4) on the Actions tab, click 'View overview'
    --the overview will be shown in a preview pane.

#### Any background context you want to provide?
#### What are the relevant tickets?
CAL-32, DDF-2025

#### Screenshots (if appropriate)
![overview-ss](https://cloud.githubusercontent.com/assets/5922390/14574392/448e54ce-0310-11e6-95f7-6b53a4b2199d.png)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

Added Pre-Storage plugin to extract overview image, store it in the content provider
and add the URI to it to the Metacard.