### PR TITLE
CAL-34 Fix Unit Tests for NITF transformer pre-storage plugin.

### DIFF
--- a/catalog/imaging/catalog-imaging-transformer/src/test/java/com/connexta/alliance/transformer/nitf/TestPreStoragePlugin.java
+++ b/catalog/imaging/catalog-imaging-transformer/src/test/java/com/connexta/alliance/transformer/nitf/TestPreStoragePlugin.java
@@ -98,7 +98,6 @@ public class TestPreStoragePlugin {
         validate();
     }
 
-
     @Test
     public void testUpdateStorageRequest() throws PluginExecutionException {
         nitfPreStoragePlugin.process(updateStorageRequest);
@@ -112,7 +111,7 @@ public class TestPreStoragePlugin {
         Attribute overview = attributeArgumentCaptor.getAllValues().get(1);
         assertThat(thumbnail.getName(), is("thumbnail"));
         assertThat(thumbnail.getValue(), is(notNullValue()));
-        assertThat(overview.getName(), is("resource.dervied-resource-uri"));
+        assertThat(overview.getName(), is(Metacard.DERIVED_RESOURCE_URI));
         assertThat(overview.getValue(), is(notNullValue()));
     }
 


### PR DESCRIPTION
#### What does this PR do?
Fixes a unit test

#### Who is reviewing it?
@kcwire 

#### How should this be tested?
Run the unit tests.

#### Any background context you want to provide?
The unit test was failing because it was expecting a specific string value for one of the attribute names.
That name changed in DDF which caused the validation to fail.  Updated the test to rely on the DDF-defined constant value instead of a hard-coded string.

#### What are the relevant tickets?
CAL-34

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
