### PR TITLE
CAL-35 Add Maven variable for project report output directory

### DIFF
--- a/catalog/nsili/catalog-nsili-transformer/pom.xml
+++ b/catalog/nsili/catalog-nsili-transformer/pom.xml
@@ -26,10 +26,6 @@
     <packaging>jar</packaging>
     <name>Alliance :: NSILI :: Input Transformer</name>
 
-    <properties>
-        <project.report.output.directory>reports</project.report.output.directory>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>com.connexta.alliance.nsili</groupId>
@@ -65,36 +61,12 @@
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>default-prepare-agent</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report</id>
-                        <phase>prepare-package</phase>
-                        <configuration>
-                            <outputDirectory>
-                                ${project.build.directory}/site/${project.report.output.directory}/jacoco/
-                            </outputDirectory>
-                        </configuration>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-
-                    <execution>
                         <id>default-check</id>
                         <goals>
                             <goal>check</goal>
                         </goals>
                         <configuration>
                             <haltOnFailure>true</haltOnFailure>
-                            <excludes>
-                                <exclude>
-                                    /src/test/
-                                </exclude>
-                            </excludes>
                             <rules>
                                 <rule>
                                     <element>BUNDLE</element>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,8 @@
         <guava.version>18.0</guava.version>
         <slf4j.version>1.7.1</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- output directory for reports -->
+        <project.report.output.directory>project-info</project.report.output.directory>
         <joda-time.version>2.2</joda-time.version>
         <jts.version>1.12</jts.version>
         <commons-lang3.version>3.4</commons-lang3.version>


### PR DESCRIPTION
#### What does this PR do?
Adds a Maven variable `project.report.output.directory` so JaCoCo reports go in a properly named folder. Also removes unnecessary JaCoCo configuration in `catalog-nsili-transformer`.

#### Who is reviewing it?
@jlcsmith 
@bdeining 

#### How should this be tested?
Build Alliance and confirm that JaCoCo's reports are in the folder `target/site/project-info/jacoco`.

#### What are the relevant tickets?
[CAL-35](https://codice.atlassian.net/browse/CAL-35)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests