### PR TITLE
CAL-36 Ingest MPEG-TS UDP Stream

### DIFF
--- a/catalog/video/catalog-mpegts-stream/pom.xml
+++ b/catalog/video/catalog-mpegts-stream/pom.xml
@@ -1,0 +1,251 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Connexta, LLC
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>alliance-video</artifactId>
+        <groupId>com.connexta.alliance.video</groupId>
+        <version>0.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>alliance-mpegts-stream</artifactId>
+    <name>Alliance :: Video :: Stream</name>
+    <packaging>bundle</packaging>
+    <dependencies>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <version>4.0.36.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>com.barchart.udt</groupId>
+            <artifactId>barchart-udt-bundle</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jcodec</groupId>
+            <artifactId>jcodec</artifactId>
+            <version>0.2.0_1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codice.ddf</groupId>
+            <artifactId>klv</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codice.ddf</groupId>
+            <artifactId>mpeg-transport-stream</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security</groupId>
+            <artifactId>ddf-security-common</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.registry</groupId>
+            <artifactId>catalog-registry-common</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform.util</groupId>
+            <artifactId>platform-util-unavailableurls</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.taktik</groupId>
+            <artifactId>mpegts-streamer</artifactId>
+            <version>0.1.0_1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.connexta.alliance</groupId>
+            <artifactId>stanag4609</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.connexta.alliance</groupId>
+            <artifactId>klv</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>${commons-collections4.version}</version>
+        </dependency>
+
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Import-Package>
+                            !com.google.protobuf.*,
+                            !com.jcraft.jzlib.*,
+                            !com.ning.compress.*,
+                            !com.puppycrawl.tools.checkstyle.api.*,
+                            !com.sun.nio.sctp.*,
+                            !gnu.io.*,
+                            !javassist.*,
+                            !lzma.sdk.*,
+                            !net.jpountz.lz4.*,
+                            !net.jpountz.xxhash.*,
+                            !org.apache.tomcat.jni.*,
+                            !org.bouncycastle.cert.*,
+                            !org.bouncycastle.operator.*,
+                            !org.bouncycastle.asn1.x500.*,
+                            !org.bouncycastle.jce.provider.*,
+                            !org.bouncycastle.crypto.*,
+                            !org.eclipse.jetty.alpn.*,
+                            !org.eclipse.jetty.npn.*,
+                            !org.jboss.marshalling.*,
+                            !org.junit.runner.notification.*,
+                            !sun.security.util.*,
+                            !sun.security.x509.*,
+                            !com.connexta.transformer.video.*,
+                            !org.apache.commons.collections4.*,
+                            *
+                        </Import-Package>
+                        <Embed-Dependency>
+                            netty-all,
+                            barchart-udt-bundle,
+                            jcodec,
+                            mpegts-streamer,
+                            catalog-core-api-impl,
+                            platform-util,
+                            ddf-security-common,
+                            catalog-registry-common,
+                            platform-util-unavailableurls,
+                            commons-lang3,
+                            commons-collections4
+                        </Embed-Dependency>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/classes</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/main/resources</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.76</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.59</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.69</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/Constants.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/Constants.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts;
+
+public class Constants {
+
+    public static final String MPEGTS_MIME_TYPE = "video/mp2t";
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/OutputStreamFactory.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/OutputStreamFactory.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.OutputStream;
+
+/**
+ * Factory for create OutputStream objects.
+ */
+public interface OutputStreamFactory {
+
+    /**
+     * Create an OutputStream that writes to a file and supports appending.
+     *
+     * @param file   must be non-null
+     * @param append must be non-null
+     * @return a non-null value
+     * @throws FileNotFoundException
+     */
+    OutputStream create(File file, boolean append) throws FileNotFoundException;
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/StreamMonitor.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/StreamMonitor.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts;
+
+import java.net.URI;
+import java.util.Optional;
+
+public interface StreamMonitor {
+
+    /**
+     * Get the URI of the stream associated with this stream processor.
+     *
+     * @return optional uri of the stream
+     */
+    Optional<URI> getStreamUri();
+
+    /**
+     * Get the title string to be used for the parent metacard.
+     *
+     * @return optional title of the stream
+     */
+    Optional<String> getTitle();
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/UdpStreamMonitor.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/UdpStreamMonitor.java
@@ -1,0 +1,454 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts;
+
+import static org.apache.commons.lang3.Validate.inclusiveBetween;
+import static org.apache.commons.lang3.Validate.notBlank;
+import static org.apache.commons.lang3.Validate.notNull;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.connexta.alliance.libs.klv.KlvHandler;
+import com.connexta.alliance.libs.klv.KlvHandlerFactory;
+import com.connexta.alliance.libs.klv.KlvProcessor;
+import com.connexta.alliance.libs.klv.Stanag4609Processor;
+import com.connexta.alliance.video.stream.mpegts.filename.FilenameGenerator;
+import com.connexta.alliance.video.stream.mpegts.netty.UdpStreamProcessor;
+import com.connexta.alliance.video.stream.mpegts.rollover.RolloverCondition;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.data.MetacardType;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+
+/**
+ * Starts a Netty server with a pipeline specified by {@link UdpStreamProcessor}. The following
+ * properties must be set:
+ * <ul>
+ * <li>{@link #setMonitoredAddress(String)}
+ * <li>{@link #setMonitoredPort(Integer)}
+ * <li>{@link #setFilenameTemplate(String)}
+ * <li>{@link #setRolloverCondition(RolloverCondition)}
+ * <li>{@link #setFilenameGenerator(FilenameGenerator)}
+ * <li>{@link #setStanag4609Processor(Stanag4609Processor)}
+ * <li>{@link #setKlvHandlerFactory(KlvHandlerFactory)}
+ * <li>{@link #setDefaultKlvHandler(KlvHandler)}
+ * <li>{@link #setKlvProcessor(KlvProcessor)}
+ * <li>{@link #setMetacardTypeList(List)}
+ * <li>{@link #setCatalogFramework(CatalogFramework)}
+ * </ul>
+ */
+public class UdpStreamMonitor implements StreamMonitor {
+
+    public static final int BYTE_COUNT_MIN = 1;
+
+    public static final int BYTE_COUNT_MAX = Integer.MAX_VALUE;
+
+    public static final long ELAPSED_TIME_MIN = 1;
+
+    public static final long ELAPSED_TIME_MAX = Long.MAX_VALUE;
+
+    public static final int SUBSAMPLE_COUNT_MIN = 1;
+
+    public static final int SUBSAMPLE_COUNT_MAX = Integer.MAX_VALUE;
+
+    static final int MONITORED_PORT_MIN = 1;
+
+    static final int MONITORED_PORT_MAX = 65535;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UdpStreamMonitor.class);
+
+    /**
+     * This is the id string used in metatype.xml.
+     */
+    private static final String METATYPE_MONITORED_ADDRESS = "monitoredAddress";
+
+    /**
+     * This is the id string used in metatype.xml.
+     */
+    private static final String METATYPE_MONITORED_PORT = "monitoredPort";
+
+    /**
+     * This is the id string used in metatype.xml.
+     */
+    private static final String METATYPE_BYTE_COUNT_ROLLOVER_CONDITION =
+            "byteCountRolloverCondition";
+
+    /**
+     * This is the id string used in metatype.xml.
+     */
+    private static final String METATYPE_ELAPSED_TIME_ROLLOVER_CONDITION =
+            "elapsedTimeRolloverCondition";
+
+    /**
+     * This is the id string used in metatype.xml.
+     */
+    private static final String METATYPE_FILENAME_TEMPLATE = "filenameTemplate";
+
+    private UdpStreamProcessor udpStreamProcessor;
+
+    private String monitoredAddress;
+
+    private Integer monitoredPort;
+
+    private EventLoopGroup eventLoopGroup = new NioEventLoopGroup();
+
+    private Thread serverThread;
+
+    private Bootstrap bootstrap = new Bootstrap();
+
+    private String parentTitle;
+
+    public UdpStreamMonitor() {
+        udpStreamProcessor = new UdpStreamProcessor(this);
+    }
+
+    UdpStreamMonitor(UdpStreamProcessor udpStreamProcessor) {
+        this.udpStreamProcessor = udpStreamProcessor;
+    }
+
+    /**
+     * @param klvHandlerFactory must be non-null
+     */
+    public void setKlvHandlerFactory(KlvHandlerFactory klvHandlerFactory) {
+        notNull(klvHandlerFactory, "klvHandlerFactory must be non-null");
+        udpStreamProcessor.setKlvHandlerFactory(klvHandlerFactory);
+    }
+
+    /**
+     * @param klvProcessor must be non-null
+     */
+    public void setKlvProcessor(KlvProcessor klvProcessor) {
+        notNull(klvProcessor, "klvProcessor must be non-null");
+        udpStreamProcessor.setKlvProcessor(klvProcessor);
+    }
+
+    /**
+     * @param klvLocationSubsampleCount must be non-null and >= {@link #SUBSAMPLE_COUNT_MIN}
+     */
+    public void setKlvLocationSubsampleCount(Integer klvLocationSubsampleCount) {
+        notNull(klvLocationSubsampleCount, "klvLocationSubsampleCount mus be non-null");
+        inclusiveBetween(SUBSAMPLE_COUNT_MIN,
+                SUBSAMPLE_COUNT_MAX,
+                klvLocationSubsampleCount,
+                String.format("klvLocationSubsampleCount must be %d <= count <= %d",
+                        SUBSAMPLE_COUNT_MIN,
+                        SUBSAMPLE_COUNT_MAX));
+        udpStreamProcessor.setKlvLocationSubsampleCount(klvLocationSubsampleCount);
+    }
+
+    /**
+     * @param defaultKlvHandler must be non-null
+     */
+    public void setDefaultKlvHandler(KlvHandler defaultKlvHandler) {
+        notNull(defaultKlvHandler, "defaultKlvHandler must be non-null");
+        udpStreamProcessor.setDefaultKlvHandler(defaultKlvHandler);
+    }
+
+    /**
+     * @param stanag4609Processor must be non-null
+     */
+    public void setStanag4609Processor(Stanag4609Processor stanag4609Processor) {
+        notNull(stanag4609Processor, "stanag4609Processor must be non-null");
+        udpStreamProcessor.setStanag4609Processor(stanag4609Processor);
+    }
+
+    /**
+     * @param filenameGenerator must be non-null
+     */
+    public void setFilenameGenerator(FilenameGenerator filenameGenerator) {
+        notNull(filenameGenerator, "filenameGenerator must be non-null");
+        udpStreamProcessor.setFilenameGenerator(filenameGenerator);
+    }
+
+    /**
+     * @param template must be non-null and non-blank
+     */
+    public void setFilenameTemplate(String template) {
+        notNull(template, "template must be non-null");
+        notBlank(template, "template must be non-blank");
+        udpStreamProcessor.setFilenameTemplate(template);
+    }
+
+    /**
+     * @param rolloverCondition must be non-null
+     */
+    public void setRolloverCondition(RolloverCondition rolloverCondition) {
+        notNull(rolloverCondition, "rolloverCondition must be non-null");
+        udpStreamProcessor.setRolloverCondition(rolloverCondition);
+    }
+
+    private boolean isReady() {
+        return monitoredAddress != null && monitoredPort != null && udpStreamProcessor.isReady();
+    }
+
+    /**
+     * Called by osgi to initial the monitor. Makes sure it is already shutdown before initializing.
+     * Will throw a RuntimeException if not properly initialized.
+     */
+    public void init() {
+        LOGGER.debug("--init-- entering");
+
+        shutdown();
+
+        if (isReady()) {
+
+            LOGGER.info(
+                    "initializing udp stream monitor: monitoredAddress={}, monitoredPort={}, udpStreamProcessor={}",
+                    monitoredAddress,
+                    monitoredPort,
+                    udpStreamProcessor);
+
+            udpStreamProcessor.init();
+
+            serverThread = new Thread(new Server());
+            serverThread.start();
+
+        } else {
+            throw new RuntimeException(String.format(
+                    "the udp stream monitor cannot be initialized because it is not properly configured: monitoredAddress=%s, monitoredPort=%s, udpStreamProcessor=%s",
+                    monitoredAddress,
+                    monitoredPort,
+                    udpStreamProcessor));
+        }
+
+    }
+
+    public void setParentTitle(String parentTitle) {
+        notNull(parentTitle, "parentTitle must be non-null");
+        this.parentTitle = parentTitle;
+    }
+
+    @Override
+    public Optional<URI> getStreamUri() {
+        if (monitoredAddress == null || monitoredPort == null) {
+            return Optional.empty();
+        }
+        return Optional.of(URI.create("udp://" + monitoredAddress + ":" + monitoredPort));
+    }
+
+    @Override
+    public Optional<String> getTitle() {
+        return Optional.ofNullable(parentTitle);
+    }
+
+    /**
+     * @param metacardTypeList must be non-null
+     */
+    public void setMetacardTypeList(List<MetacardType> metacardTypeList) {
+        notNull(metacardTypeList, "metacardTypeList must be non-null");
+        udpStreamProcessor.setMetacardTypeList(metacardTypeList);
+    }
+
+    /**
+     * @param catalogFramework must be non-null
+     */
+    public void setCatalogFramework(CatalogFramework catalogFramework) {
+        notNull(catalogFramework, "catalogFramework must be non-null");
+        udpStreamProcessor.setCatalogFramework(catalogFramework);
+    }
+
+    /**
+     * Called by osgi to destroy the monitor.
+     *
+     * @param arg osgi destroy argument
+     */
+    public void destroy(int arg) {
+
+        LOGGER.debug("--destroy-- : arg={}", arg);
+
+        shutdown();
+    }
+
+    private void shutdown() {
+        if (serverThread != null) {
+            eventLoopGroup.shutdownGracefully();
+
+            joinServerThread();
+
+            serverThread = null;
+
+            udpStreamProcessor.shutdown();
+        }
+    }
+
+    private void joinServerThread() {
+        try {
+            serverThread.join();
+        } catch (InterruptedException e) {
+            LOGGER.warn("interrupted while waiting for server thread to join", e);
+        }
+    }
+
+    /**
+     * Called by osgi to update the properties defined in metatype.xml
+     *
+     * @param properties properties being updated
+     */
+    public void updateCallback(Map<String, Object> properties) {
+        LOGGER.debug("--updateCallback-- properties={}", properties);
+        if (properties != null) {
+
+            if (!checkMetaTypeClass(properties, METATYPE_MONITORED_ADDRESS, String.class)) {
+                return;
+            }
+            if (!checkMetaTypeClass(properties, METATYPE_MONITORED_PORT, Integer.class)) {
+                return;
+            }
+            if (!checkMetaTypeClass(properties,
+                    METATYPE_BYTE_COUNT_ROLLOVER_CONDITION,
+                    Integer.class)) {
+                return;
+            }
+            if (!checkMetaTypeClass(properties,
+                    METATYPE_ELAPSED_TIME_ROLLOVER_CONDITION,
+                    Long.class)) {
+                return;
+            }
+            if (!checkMetaTypeClass(properties, METATYPE_FILENAME_TEMPLATE, String.class)) {
+                return;
+            }
+
+            setMonitoredAddress((String) properties.get(METATYPE_MONITORED_ADDRESS));
+            setMonitoredPort((Integer) properties.get(METATYPE_MONITORED_PORT));
+            setByteCountRolloverCondition((Integer) properties.get(
+                    METATYPE_BYTE_COUNT_ROLLOVER_CONDITION));
+            setElapsedTimeRolloverCondition((Long) properties.get(
+                    METATYPE_ELAPSED_TIME_ROLLOVER_CONDITION));
+            setFilenameTemplate((String) properties.get(METATYPE_FILENAME_TEMPLATE));
+
+            init();
+        }
+    }
+
+    private boolean checkMetaTypeClass(Map<String, Object> properties, String fieldName,
+            Class<?> clazz) {
+        if (!properties.containsKey(fieldName)) {
+            LOGGER.warn("the metatype id {} field was null", fieldName);
+            return false;
+        }
+        if (!clazz.isInstance(properties.get(fieldName))) {
+            LOGGER.warn("the metatype id {} field should be type {}", fieldName, clazz);
+            return false;
+        }
+        return true;
+    }
+
+    public Integer getMonitoredPort() {
+        return monitoredPort;
+    }
+
+    /**
+     * @param monitoredPort must be non-null and {@link #MONITORED_PORT_MIN} <= port <= {@link #MONITORED_PORT_MAX}
+     */
+    public void setMonitoredPort(Integer monitoredPort) {
+        notNull(monitoredPort, "monitoredPort must be non-null");
+        inclusiveBetween(MONITORED_PORT_MIN,
+                MONITORED_PORT_MAX,
+                monitoredPort,
+                String.format("monitoredPort must be >=%d and <=%d",
+                        MONITORED_PORT_MIN,
+                        MONITORED_PORT_MAX));
+
+        this.monitoredPort = monitoredPort;
+    }
+
+    public String getMonitoredAddress() {
+        return monitoredAddress;
+    }
+
+    /**
+     * @param monitoredAddress must be non-null and resolvable
+     */
+    public void setMonitoredAddress(String monitoredAddress) {
+        notNull(monitoredAddress, "monitoredAddress must be non-null");
+
+        try {
+            // ignore return
+            InetAddress.getByName(monitoredAddress);
+        } catch (UnknownHostException e) {
+            throw new IllegalArgumentException(String.format(
+                    "the monitored address could not be resolved: monitoredAddress=%s",
+                    monitoredAddress));
+        }
+
+        this.monitoredAddress = monitoredAddress;
+    }
+
+    /**
+     * @param count must be non-null and positive
+     */
+    public void setByteCountRolloverCondition(Integer count) {
+        notNull(count, "count must be non-null");
+
+        inclusiveBetween(BYTE_COUNT_MIN,
+                BYTE_COUNT_MAX,
+                count,
+                String.format("count must be >=%d", BYTE_COUNT_MIN));
+        udpStreamProcessor.setByteCountRolloverCondition(count);
+    }
+
+    /**
+     * @param milliseconds must be non-null and >= {@link #ELAPSED_TIME_MIN}
+     */
+    public void setElapsedTimeRolloverCondition(Long milliseconds) {
+        notNull(milliseconds, "milliseconds must be non-null");
+        inclusiveBetween(ELAPSED_TIME_MIN,
+                ELAPSED_TIME_MAX,
+                milliseconds,
+                String.format("milliseconds must be >=%d", ELAPSED_TIME_MIN));
+        udpStreamProcessor.setElapsedTimeRolloverCondition(milliseconds);
+    }
+
+    private class Server implements Runnable {
+
+        @Override
+        public void run() {
+
+            bootstrap.group(eventLoopGroup)
+                    .channel(NioDatagramChannel.class)
+                    .handler(new ChannelInitializer<NioDatagramChannel>() {
+
+                        @Override
+                        protected void initChannel(NioDatagramChannel nioDatagramChannel)
+                                throws Exception {
+                            nioDatagramChannel.pipeline()
+                                    .addLast(udpStreamProcessor.createChannelHandlers());
+                        }
+                    });
+            try {
+                bootstrap.bind(monitoredAddress, monitoredPort)
+                        .sync()
+                        .channel()
+                        .closeFuture()
+                        .await();
+            } catch (InterruptedException e) {
+                LOGGER.warn("interrupted while waiting for shutdown", e);
+            }
+
+        }
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/filename/BaseFilenameGenerator.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/filename/BaseFilenameGenerator.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.filename;
+
+import static org.apache.commons.lang3.Validate.notNull;
+
+/**
+ * Declares a template method and calls the template method with non-null value.
+ */
+abstract class BaseFilenameGenerator implements FilenameGenerator {
+
+    @Override
+    public final String generateFilename(String baseFilename) {
+        notNull(baseFilename, "baseFilename must be non-null");
+        return doGenerateFilename(baseFilename);
+    }
+
+    /**
+     * {@link #generateFilename(String)}
+     *
+     * @param baseFilename guaranteed to be non-null
+     * @return the transformed filename
+     */
+    protected abstract String doGenerateFilename(String baseFilename);
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/filename/DateTemplateFilenameGenerator.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/filename/DateTemplateFilenameGenerator.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.filename;
+
+import static org.apache.commons.lang3.Validate.notNull;
+
+import java.util.Date;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.time.FastDateFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Replaces one or more tokens within a filename with the current time. The format of the token is
+ * <code>%{date=FMT}</code>, where <code>FMT</code> is format string defined by
+ * SimpleDateFormat.
+ */
+public class DateTemplateFilenameGenerator extends BaseFilenameGenerator {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(DateTemplateFilenameGenerator.class);
+
+    private static final String PREFIX = "%{date=";
+
+    private static final String SUFFIX = "}";
+
+    private static final String REGEX = ".*" + Pattern.quote(PREFIX) + "([^}]+)" + Pattern.quote(
+            SUFFIX) + ".*";
+
+    private static final Pattern PATTERN = Pattern.compile(REGEX);
+
+    /**
+     * This capture group number must agree with the groupings in {@link #REGEX}.
+     */
+    private static final int CAPTURE_GROUP = 1;
+
+    /**
+     * By default, new Date objects are created by calling {@link Date#Date()}. This can
+     * be changed by setting a new {@link Supplier} with {@link #setDateSupplier(Supplier)}.
+     */
+    private Supplier<Date> dateSupplier = Date::new;
+
+    /**
+     * Set an alternative DateSupplier to the default.
+     *
+     * @param dateSupplier must be non-null
+     */
+    public void setDateSupplier(Supplier<Date> dateSupplier) {
+        notNull(dateSupplier, "dateSupplier must be non-null");
+        this.dateSupplier = dateSupplier;
+    }
+
+    @Override
+    protected String doGenerateFilename(String baseFilename) {
+
+        String tmp = baseFilename;
+
+        Matcher m = PATTERN.matcher(tmp);
+        while (m.matches()) {
+            String fmt = m.group(CAPTURE_GROUP);
+            String formattedDate = FastDateFormat.getInstance(fmt)
+                    .format(dateSupplier.get());
+            String newBaseFilename = tmp.replace(PREFIX + fmt + SUFFIX, formattedDate);
+            if (newBaseFilename.equals(tmp)) {
+                LOGGER.warn("failed to replace date tokens: baseFilename={}", baseFilename);
+                return tmp;
+            }
+            tmp = newBaseFilename;
+            m = PATTERN.matcher(tmp);
+        }
+
+        return tmp;
+    }
+
+    @Override
+    public String toString() {
+        return "DateTemplateFilenameGenerator{}";
+    }
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/filename/FileExtensionFilenameGenerator.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/filename/FileExtensionFilenameGenerator.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.filename;
+
+/**
+ * Ensures that a filename always ends with a specific extension. If the filename does not
+ * end with the specified extension, then it adds it to the filename. Does not attempt to
+ * rewrite an existing extension. The test is case-insensitive.
+ */
+public class FileExtensionFilenameGenerator extends BaseFilenameGenerator {
+
+    private final String extension;
+
+    public FileExtensionFilenameGenerator(String extension) {
+        this.extension = extension;
+    }
+
+    @Override
+    protected String doGenerateFilename(String baseFilename) {
+        if (baseFilename.toLowerCase()
+                .endsWith("." + extension.toLowerCase())) {
+            return baseFilename;
+        }
+        return baseFilename + "." + extension;
+    }
+
+    @Override
+    public String toString() {
+        return "FileExtensionFilenameGenerator{" +
+                "extension='" + extension + '\'' +
+                '}';
+    }
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/filename/FilenameGenerator.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/filename/FilenameGenerator.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.filename;
+
+/**
+ * Generate a filename based on base filename or template.
+ */
+public interface FilenameGenerator {
+
+    /**
+     * @param baseFilename the base filename or template, must be non-null
+     * @return a non-null value
+     */
+    String generateFilename(String baseFilename);
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/filename/IllegalCharactersFilenameGenerator.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/filename/IllegalCharactersFilenameGenerator.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.filename;
+
+/**
+ * Removes illegal characters from a filename.
+ */
+public class IllegalCharactersFilenameGenerator extends BaseFilenameGenerator {
+
+    /**
+     * These are regexes that are supplied to {@link String#replaceAll(String, String)}.
+     */
+    private static final String[] ILLEGAL_CHARACTERS_REGEXES = new String[] {"/", ":"};
+
+    private static final String REPLACE_WITH = "";
+
+    @Override
+    protected String doGenerateFilename(String baseFilename) {
+        String tmp = baseFilename;
+        for (String illegalCharacterRegex : ILLEGAL_CHARACTERS_REGEXES) {
+            tmp = tmp.replaceAll(illegalCharacterRegex, REPLACE_WITH);
+        }
+        return tmp;
+    }
+
+    @Override
+    public String toString() {
+        return "IllegalCharactersFilenameGenerator{}";
+    }
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/filename/ListFilenameGenerator.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/filename/ListFilenameGenerator.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.filename;
+
+import java.util.List;
+
+/**
+ * Contains a list of FilenameGenerator objects and chains those objects together.
+ */
+public class ListFilenameGenerator extends BaseFilenameGenerator {
+
+    private final List<FilenameGenerator> filenameGeneratorList;
+
+    public ListFilenameGenerator(List<FilenameGenerator> filenameGeneratorList) {
+        this.filenameGeneratorList = filenameGeneratorList;
+    }
+
+    @Override
+    protected String doGenerateFilename(String baseFilename) {
+        String tmp = baseFilename;
+        for (FilenameGenerator filenameGenerator : filenameGeneratorList) {
+            tmp = filenameGenerator.generateFilename(tmp);
+        }
+        return tmp;
+    }
+
+    @Override
+    public String toString() {
+        return "ListFilenameGenerator{" +
+                "filenameGeneratorList=" + filenameGeneratorList +
+                '}';
+    }
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/filename/TempFileGenerator.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/filename/TempFileGenerator.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.filename;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Generate temporary files. Implementations should should call
+ * {@link File#deleteOnExit()} on the file object before returning it if
+ * the creation of that object results in the automatic creation of the
+ * actual file.
+ */
+public interface TempFileGenerator {
+
+    /**
+     * Return a temporary file.
+     *
+     * @return non-null File object
+     * @throws IOException
+     */
+    File generate() throws IOException;
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/filename/TempFileGeneratorImpl.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/filename/TempFileGeneratorImpl.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.filename;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Creates a File object with {@link File#createTempFile(String, String)} where the file
+ * always begins with "mpegts-stream-" and ends with ".ts".
+ */
+public class TempFileGeneratorImpl implements TempFileGenerator {
+
+    private static final String TEMP_FILE_PREFIX = "mpegts-stream-";
+
+    private static final String TEMP_FILE_SUFFIX = ".ts";
+
+    @Override
+    public File generate() throws IOException {
+        File file = File.createTempFile(TEMP_FILE_PREFIX, TEMP_FILE_SUFFIX);
+        file.deleteOnExit();
+        return file;
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/metacard/FrameCenterMetacardUpdater.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/metacard/FrameCenterMetacardUpdater.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.metacard;
+
+import com.connexta.alliance.libs.klv.AttributeNameConstants;
+
+public class FrameCenterMetacardUpdater extends LineStringMetacardUpdater {
+    public FrameCenterMetacardUpdater() {
+        super(AttributeNameConstants.FRAME_CENTER);
+    }
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/metacard/LineStringMetacardUpdater.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/metacard/LineStringMetacardUpdater.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.metacard;
+
+import java.io.Serializable;
+import java.util.Optional;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import com.connexta.alliance.libs.klv.GeometryUtility;
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.LineString;
+import com.vividsolutions.jts.io.WKTReader;
+import com.vividsolutions.jts.io.WKTWriter;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+
+public class LineStringMetacardUpdater implements MetacardUpdater {
+
+    private final String attributeName;
+
+    public LineStringMetacardUpdater(String attributeName) {
+        this.attributeName = attributeName;
+    }
+
+    @Override
+    public void update(Metacard parent, Metacard child) {
+        if (!hasFrameCenter(parent) && hasFrameCenter(child)) {
+            setAttribute(parent, child);
+        } else if (hasFrameCenter(parent) && hasFrameCenter(child)) {
+            WKTReader wktReader = new WKTReader();
+
+            Optional<Geometry> parentGeo = GeometryUtility.wktToGeometry(getValue(parent),
+                    wktReader);
+            Optional<Geometry> childGeo = GeometryUtility.wktToGeometry(getValue(child), wktReader);
+
+            if (parentGeo.isPresent() && childGeo.isPresent()) {
+                Coordinate[] coordinates = getMergedCoordinates(parentGeo, childGeo);
+                LineString lineString = convertCoordinatesToLineString(coordinates);
+                setAttribute(parent, lineString);
+            }
+
+        }
+    }
+
+    private Attribute createAttribute(Serializable value) {
+        return new AttributeImpl(attributeName, value);
+    }
+
+    private void setAttribute(Metacard parent, Metacard child) {
+        parent.setAttribute(createAttribute(child.getAttribute(attributeName)
+                .getValue()));
+    }
+
+    private void setAttribute(Metacard parent, LineString lineString) {
+        WKTWriter wktWriter = new WKTWriter();
+        parent.setAttribute(createAttribute(wktWriter.write(lineString.norm())));
+    }
+
+    private Coordinate[] getMergedCoordinates(Optional<Geometry> parentGeo,
+            Optional<Geometry> childGeo) {
+        return ArrayUtils.addAll(parentGeo.get()
+                        .getCoordinates(),
+                childGeo.get()
+                        .getCoordinates());
+    }
+
+    private String getValue(Metacard metacard) {
+        return (String) metacard.getAttribute(attributeName)
+                .getValue();
+    }
+
+    private boolean hasFrameCenter(Metacard metacard) {
+        return metacard.getAttribute(attributeName) != null && metacard.getAttribute(attributeName)
+                .getValue() instanceof String;
+    }
+
+    private LineString convertCoordinatesToLineString(Coordinate[] coordinates) {
+        return new GeometryFactory().createLineString(coordinates);
+    }
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/metacard/ListMetacardUpdater.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/metacard/ListMetacardUpdater.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.metacard;
+
+import java.util.List;
+
+import ddf.catalog.data.Metacard;
+
+public class ListMetacardUpdater implements MetacardUpdater {
+
+    private final List<MetacardUpdater> metacardUpdaterList;
+
+    public ListMetacardUpdater(List<MetacardUpdater> metacardUpdaterList) {
+        this.metacardUpdaterList = metacardUpdaterList;
+    }
+
+    @Override
+    public void update(Metacard parent, Metacard child) {
+        metacardUpdaterList.forEach(metacardUpdater -> metacardUpdater.update(parent, child));
+    }
+
+    @Override
+    public String toString() {
+        return "ListMetacardUpdater{" +
+                "metacardUpdaterList=" + metacardUpdaterList +
+                '}';
+    }
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/metacard/LocationMetacardUpdater.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/metacard/LocationMetacardUpdater.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.metacard;
+
+import java.util.Optional;
+
+import com.connexta.alliance.libs.klv.GeometryUtility;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.io.WKTReader;
+import com.vividsolutions.jts.io.WKTWriter;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+
+public class LocationMetacardUpdater implements MetacardUpdater {
+
+    @Override
+    public void update(Metacard parent, Metacard child) {
+        if (parent.getLocation() == null) {
+            setParentLocation(parent, child.getLocation());
+        } else if (child.getLocation() != null) {
+            locationUnion(parent, child).ifPresent(wkt -> setParentLocation(parent, wkt));
+        }
+    }
+
+    private void setParentLocation(Metacard parent, String location) {
+        parent.setAttribute(new AttributeImpl(Metacard.GEOGRAPHY, location));
+    }
+
+    private Optional<String> locationUnion(Metacard metacard1, Metacard metacard2) {
+
+        WKTReader wktReader = new WKTReader();
+
+        Optional<Geometry> parentGeometry = GeometryUtility.wktToGeometry(metacard1.getLocation(),
+                wktReader);
+        Optional<Geometry> childGeometry = GeometryUtility.wktToGeometry(metacard2.getLocation(),
+                wktReader);
+
+        if (parentGeometry.isPresent() && childGeometry.isPresent()) {
+            return Optional.of(new WKTWriter().write(parentGeometry.get()
+                    .union(childGeometry.get())));
+        }
+
+        return Optional.empty();
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/metacard/MetacardUpdater.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/metacard/MetacardUpdater.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.metacard;
+
+import ddf.catalog.data.Metacard;
+
+public interface MetacardUpdater {
+
+    void update(Metacard parent, Metacard child);
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/metacard/ModifiedDateMetacardUpdater.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/metacard/ModifiedDateMetacardUpdater.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.metacard;
+
+import java.util.Date;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+
+public class ModifiedDateMetacardUpdater implements MetacardUpdater {
+    @Override
+    public void update(Metacard parent, Metacard child) {
+        parent.setAttribute(new AttributeImpl(Metacard.MODIFIED, new Date()));
+    }
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/metacard/TemporalEndMetacardUpdater.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/metacard/TemporalEndMetacardUpdater.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.metacard;
+
+import com.connexta.alliance.libs.klv.AttributeNameConstants;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+
+/**
+ * If the child has an end time, then set the parent's end time to the child's value.
+ */
+public class TemporalEndMetacardUpdater implements MetacardUpdater {
+
+    private static final String ATTRIBUTE_NAME = AttributeNameConstants.TEMPORAL_END;
+
+    @Override
+    public void update(Metacard parent, Metacard child) {
+        if (child.getAttribute(ATTRIBUTE_NAME) != null) {
+            parent.setAttribute(new AttributeImpl(ATTRIBUTE_NAME,
+                    child.getAttribute(ATTRIBUTE_NAME)
+                            .getValue()));
+        }
+    }
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/metacard/TemporalStartMetacardUpdater.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/metacard/TemporalStartMetacardUpdater.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.metacard;
+
+import com.connexta.alliance.libs.klv.AttributeNameConstants;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+
+/**
+ * If the parent does not have a start time and the child does have a start time, then set the
+ * parent start to time to the child's start time.
+ */
+public class TemporalStartMetacardUpdater implements MetacardUpdater {
+
+    /**
+     * Metacard attribute name
+     */
+    static final String ATTRIBUTE_NAME = AttributeNameConstants.TEMPORAL_START;
+
+    @Override
+    public void update(Metacard parent, Metacard child) {
+        if (parent.getAttribute(ATTRIBUTE_NAME) == null
+                && child.getAttribute(ATTRIBUTE_NAME) != null) {
+            parent.setAttribute(new AttributeImpl(ATTRIBUTE_NAME,
+                    child.getAttribute(ATTRIBUTE_NAME)
+                            .getValue()));
+        }
+    }
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/netty/DecodedStreamData.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/netty/DecodedStreamData.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.netty;
+
+import static org.apache.commons.lang3.Validate.notNull;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.jcodec.codecs.h264.io.model.NALUnit;
+
+import com.connexta.alliance.libs.stanag4609.DecodedKLVMetadataPacket;
+
+/**
+ * POJO that contains decoded stream data (H264 video data or metadata). It is intended for the
+ * object to contain only NALUnit data or metadata, but never both at the same time.
+ */
+class DecodedStreamData {
+
+    private final int packetId;
+
+    private List<NALUnit> nalUnits = null;
+
+    private DecodedKLVMetadataPacket decodedKLVMetadataPacket = null;
+
+    /**
+     * @param nalUnits must be non-null
+     * @param packetId the MPEG-TS packet id associated with data
+     */
+    public DecodedStreamData(List<NALUnit> nalUnits, int packetId) {
+        notNull(nalUnits, "nalUnits must be non-null");
+        this.nalUnits = nalUnits;
+        this.packetId = packetId;
+    }
+
+    /**
+     * @param decodedKLVMetadataPacket must be non-null
+     * @param packetId                 the MPEG-TS packet id associated with data
+     */
+    public DecodedStreamData(DecodedKLVMetadataPacket decodedKLVMetadataPacket, int packetId) {
+        notNull(decodedKLVMetadataPacket, "decodedKLVMetadataPacket must be non-null");
+        this.decodedKLVMetadataPacket = decodedKLVMetadataPacket;
+        this.packetId = packetId;
+    }
+
+    public int getPacketId() {
+        return packetId;
+    }
+
+    /**
+     * @return non-null value
+     */
+    public Optional<List<NALUnit>> getNalUnits() {
+        return Optional.ofNullable(nalUnits);
+    }
+
+    /**
+     * @return non-null value
+     */
+    public Optional<DecodedKLVMetadataPacket> getDecodedKLVMetadataPacket() {
+        return Optional.ofNullable(decodedKLVMetadataPacket);
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/netty/DecodedStreamDataHandler.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/netty/DecodedStreamDataHandler.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.netty;
+
+import static org.apache.commons.lang3.Validate.notNull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+
+import org.jcodec.codecs.h264.io.model.NALUnit;
+import org.jcodec.codecs.h264.io.model.NALUnitType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.connexta.alliance.libs.klv.KlvHandler;
+import com.connexta.alliance.libs.klv.Stanag4609Processor;
+import com.connexta.alliance.libs.stanag4609.DecodedKLVMetadataPacket;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+/**
+ * Netty handler for {@link DecodedStreamData}. If called with video data, then tells the
+ * PacketBuffer if the data contains an IDR or NON-IDR frame. If called with metadata, then
+ * calls the KlvHandlers.
+ */
+class DecodedStreamDataHandler extends ChannelInboundHandlerAdapter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DecodedStreamDataHandler.class);
+
+    private final PacketBuffer packetBuffer;
+
+    private final Stanag4609Processor stanag4609Processor;
+
+    private final Map<String, KlvHandler> klvHandlerMap;
+
+    private final KlvHandler defaultKlvHandler;
+
+    private final Lock klvHandlerMapLock;
+
+    public DecodedStreamDataHandler(PacketBuffer packetBuffer,
+            Stanag4609Processor stanag4609Processor, Map<String, KlvHandler> klvHandlerMap,
+            KlvHandler defaultKlvHandler, Lock klvHandlerMapLock) {
+
+        notNull(packetBuffer, "packetBuffer must be non-null");
+        notNull(stanag4609Processor, "stanag4609Processor must be non-null");
+        notNull(klvHandlerMap, "klvHandlerMap must be non-null");
+        notNull(defaultKlvHandler, "defaultKlvHandler must be non-null");
+        notNull(klvHandlerMapLock, "klvHandlerMapLocl must be non-null");
+
+        this.packetBuffer = packetBuffer;
+        this.stanag4609Processor = stanag4609Processor;
+        this.klvHandlerMap = klvHandlerMap;
+        this.defaultKlvHandler = defaultKlvHandler;
+        this.klvHandlerMapLock = klvHandlerMapLock;
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+
+        if (!(msg instanceof DecodedStreamData)) {
+            LOGGER.error("handler passed incorrect data type, must be DecodedStreamData, but was {}",
+                    msg.getClass());
+            return;
+        }
+
+        DecodedStreamData decodedStreamData = (DecodedStreamData) msg;
+
+        decodedStreamData.getNalUnits()
+                .ifPresent(this::handleNALUnits);
+
+        decodedStreamData.getDecodedKLVMetadataPacket()
+                .ifPresent(decodedKLVMetadataPacket -> handleDecodedKLVMetadataPacket(
+                        decodedKLVMetadataPacket,
+                        decodedStreamData.getPacketId()));
+
+    }
+
+    private void handleNALUnits(List<NALUnit> nalUnitList) {
+
+        boolean containsIDR = nalUnitList.stream()
+                .anyMatch(nalUnit -> nalUnit.type == NALUnitType.IDR_SLICE);
+
+        packetBuffer.frameComplete(containsIDR ?
+                PacketBuffer.FrameType.IDR :
+                PacketBuffer.FrameType.NON_IDR);
+
+    }
+
+    private void handleDecodedKLVMetadataPacket(DecodedKLVMetadataPacket decodedKLVMetadataPacket,
+            int packetId) {
+
+        klvHandlerMapLock.lock();
+        try {
+            stanag4609Processor.handle(klvHandlerMap,
+                    defaultKlvHandler,
+                    Collections.singletonMap(packetId,
+                            Collections.singletonList(decodedKLVMetadataPacket)));
+        } finally {
+            klvHandlerMapLock.unlock();
+        }
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        LOGGER.error("error: ", cause);
+        ctx.close();
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/netty/MTSPacketToPESPacketDecoder.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/netty/MTSPacketToPESPacketDecoder.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.netty;
+
+import static org.apache.commons.lang3.Validate.notNull;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.jcodec.containers.mps.psi.PMTSection;
+import org.taktik.mpegts.MTSPacket;
+import org.taktik.mpegts.PATSection;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageDecoder;
+
+/**
+ * Converts a series of MTSPackets to PESPackets.
+ */
+class MTSPacketToPESPacketDecoder extends MessageToMessageDecoder<MTSPacket> {
+
+    public static final int PROGRAM_ASSOCIATION_TABLE_PID = 0;
+
+    private static final int BYTE_MASK = 0xFF;
+
+    private final Set<Integer> programMapTablePacketIdDirectory = new HashSet<>();
+
+    private final Map<Integer, PMTSection.PMTStream> programElementaryStreams = new HashMap<>();
+
+    private final Map<Integer, byte[]> currentPacketBytesByStream = new HashMap<>();
+
+    private PATSectionParser patSectionParser = PATSection::parse;
+
+    private PMTSectionParser pmtSectionParser = PMTSection::parsePMT;
+
+    public void setPatSectionParser(PATSectionParser patSectionParser) {
+        this.patSectionParser = patSectionParser;
+    }
+
+    public void setPmtSectionParser(PMTSectionParser pmtSectionParser) {
+        this.pmtSectionParser = pmtSectionParser;
+    }
+
+    @Override
+    protected void decode(ChannelHandlerContext ctx, MTSPacket mtsPacket, List<Object> outputList)
+            throws Exception {
+
+        notNull(ctx, "ctx must be non-null");
+        notNull(mtsPacket, "mtsPacket must be non-null");
+        notNull(outputList, "outputList must be non-null");
+
+        int pid = mtsPacket.getPid();
+
+        if (isProgramAssociationTable(mtsPacket, pid)) {
+
+            handleProgramAssociationTable(mtsPacket);
+
+        } else if (isProgramMapTable(mtsPacket)) {
+
+            handleProgramMapTable(mtsPacket);
+
+        } else if (isElementaryStream(pid)) {
+
+            handleElementaryStream(mtsPacket, outputList, pid);
+
+        }
+
+    }
+
+    private void handleElementaryStream(MTSPacket mtsPacket, List<Object> outputList, int pid) {
+        final PMTSection.PMTStream stream = programElementaryStreams.get(pid);
+
+        final byte[] currentPacketBytes = currentPacketBytesByStream.get(pid);
+
+        final boolean startingNewPacket = mtsPacket.isPayloadUnitStartIndicator();
+        final boolean currentPacketToHandle = currentPacketBytes != null;
+        final boolean reachedEndOfCurrentPacket = startingNewPacket && currentPacketToHandle;
+
+        final byte[] payloadBytes = getByteBufferAsBytes(mtsPacket.getPayload());
+
+        if (reachedEndOfCurrentPacket) {
+            outputList.add(new PESPacket(currentPacketBytes, stream.getStreamType(), pid));
+            currentPacketBytesByStream.put(pid, payloadBytes);
+        } else if (startingNewPacket) {
+            currentPacketBytesByStream.put(pid, payloadBytes);
+        } else if (currentPacketToHandle) {
+            final byte[] concatenatedPacket = ArrayUtils.addAll(currentPacketBytes, payloadBytes);
+            currentPacketBytesByStream.put(pid, concatenatedPacket);
+        }
+    }
+
+    private boolean isElementaryStream(int pid) {
+        return pid != PROGRAM_ASSOCIATION_TABLE_PID && !programMapTablePacketIdDirectory.contains(
+                pid) && programElementaryStreams.containsKey(pid);
+    }
+
+    private boolean isProgramMapTable(MTSPacket mtsPacket) {
+        return programMapTablePacketIdDirectory.contains(mtsPacket.getPid())
+                && mtsPacket.isPayloadUnitStartIndicator();
+    }
+
+    private boolean isProgramAssociationTable(MTSPacket mtsPacket, int pid) {
+        return pid == PROGRAM_ASSOCIATION_TABLE_PID && mtsPacket.isPayloadUnitStartIndicator();
+    }
+
+    private void handleProgramMapTable(MTSPacket mtsPacket) {
+        final ByteBuffer payload = mtsPacket.getPayload();
+
+        final int pointer = payload.get() & BYTE_MASK;
+        payload.position(payload.position() + pointer);
+
+        final PMTSection pmt = pmtSectionParser.parse(payload);
+
+        for (final PMTSection.PMTStream stream : pmt.getStreams()) {
+            programElementaryStreams.put(stream.getPid(), stream);
+        }
+    }
+
+    private void handleProgramAssociationTable(MTSPacket mtsPacket) throws IOException {
+        final ByteBuffer payload = mtsPacket.getPayload();
+
+        final int pointer = payload.get() & BYTE_MASK;
+        payload.position(payload.position() + pointer);
+        final PATSection programAssociationTable = patSectionParser.parse(payload);
+        programMapTablePacketIdDirectory.clear();
+        programMapTablePacketIdDirectory.addAll(programAssociationTable.getPrograms()
+                .values());
+
+        if (programMapTablePacketIdDirectory.isEmpty()) {
+            throw new IOException("No programs found in transport stream.");
+        }
+    }
+
+    private byte[] getByteBufferAsBytes(final ByteBuffer buffer) {
+        final byte[] bytes = new byte[buffer.remaining()];
+        buffer.get(bytes);
+        return bytes;
+    }
+
+    public interface PATSectionParser {
+        PATSection parse(ByteBuffer payload);
+    }
+
+    public interface PMTSectionParser {
+        PMTSection parse(ByteBuffer payload);
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/netty/PESPacket.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/netty/PESPacket.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.netty;
+
+import static org.apache.commons.lang3.Validate.notNull;
+
+import org.jcodec.containers.mps.MTSUtils;
+
+/**
+ * POJO that contains the payload of a PES, the stream type and the packet id.
+ */
+class PESPacket {
+
+    private final byte[] payload;
+
+    private final MTSUtils.StreamType streamType;
+
+    private final int packetId;
+
+    /**
+     * @param payload    must be non-null
+     * @param streamType must be non-null
+     * @param packetId   the packet identifier
+     */
+    public PESPacket(byte[] payload, MTSUtils.StreamType streamType, int packetId) {
+        notNull(payload, "payload must be non-null");
+        notNull(streamType, "streamType must be non-null");
+        this.payload = payload;
+        this.streamType = streamType;
+        this.packetId = packetId;
+    }
+
+    public int getPacketId() {
+        return packetId;
+    }
+
+    public byte[] getPayload() {
+        return payload;
+    }
+
+    public MTSUtils.StreamType getStreamType() {
+        return streamType;
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/netty/PESPacketToApplicationDataDecoder.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/netty/PESPacketToApplicationDataDecoder.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.netty;
+
+import static org.apache.commons.lang3.Validate.notNull;
+
+import java.nio.ByteBuffer;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.codice.ddf.libs.klv.KlvDecoder;
+import org.codice.ddf.libs.klv.KlvDecodingException;
+import org.jcodec.codecs.h264.H264Utils;
+import org.jcodec.codecs.h264.io.model.NALUnit;
+import org.jcodec.containers.mps.MTSUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.connexta.alliance.libs.stanag4609.DecodedKLVMetadataPacket;
+import com.connexta.alliance.libs.stanag4609.PESUtilities;
+import com.connexta.alliance.libs.stanag4609.Stanag4609TransportStreamParser;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageDecoder;
+
+/**
+ * Decodes PESPacket into NALUnits or decoded klv metadata. If the PES is some other type, then
+ * it is ignored.
+ */
+class PESPacketToApplicationDataDecoder extends MessageToMessageDecoder<PESPacket> {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(PESPacketToApplicationDataDecoder.class);
+
+    private final KlvDecoder klvDecoder =
+            new KlvDecoder(Stanag4609TransportStreamParser.UAS_DATALINK_LOCAL_SET_CONTEXT);
+
+    private NALReader nalReader = H264Utils::nextNALUnit;
+
+    private NALParser nalParser = NALUnit::read;
+
+    private KlvParser klvParser = PESUtilities::handlePESPacketBytes;
+
+    private boolean isKlvEnabled;
+
+    public PESPacketToApplicationDataDecoder(boolean isKlvEnabled) {
+        this.isKlvEnabled = isKlvEnabled;
+    }
+
+    /**
+     * @param nalParser must be non-null
+     */
+    public void setNalParser(NALParser nalParser) {
+        notNull(nalParser, "nalParser must be non-null");
+        this.nalParser = nalParser;
+    }
+
+    /**
+     * @param nalReader must be non-null
+     */
+    public void setNalReader(NALReader nalReader) {
+        notNull(nalReader, "nalReader must be non-null");
+        this.nalReader = nalReader;
+    }
+
+    /**
+     * @param klvParser must be non-null
+     */
+    public void setKlvParser(KlvParser klvParser) {
+        notNull(klvParser, "klvParser must be non-null");
+        this.klvParser = klvParser;
+    }
+
+    @Override
+    protected void decode(ChannelHandlerContext ctx, PESPacket pesPacket, List<Object> outputList)
+            throws Exception {
+
+        notNull(ctx, "ctx must be non-null");
+        notNull(pesPacket, "pesPacket must be non-null");
+        notNull(outputList, "outputList must be non-null");
+
+        if (isKlvEnabled && isMetadata(pesPacket)) {
+            decodeKlvMetadata(pesPacket, outputList);
+        } else if (isVideo(pesPacket)) {
+            decodeVideoH264(pesPacket, outputList);
+        }
+    }
+
+    private boolean isVideo(PESPacket pesPacket) {
+        return pesPacket.getStreamType() == MTSUtils.StreamType.VIDEO_H264;
+    }
+
+    private boolean isMetadata(PESPacket pesPacket) {
+        return pesPacket.getStreamType() == MTSUtils.StreamType.PRIVATE_DATA
+                || pesPacket.getStreamType() == MTSUtils.StreamType.META_PES;
+    }
+
+    private void decodeVideoH264(PESPacket pesPacket, List<Object> outputList) {
+        ByteBuffer p = ByteBuffer.wrap(pesPacket.getPayload());
+
+        List<NALUnit> nalUnits = new LinkedList<>();
+
+        ByteBuffer segment;
+        while ((segment = nalReader.next(p)) != null) {
+
+            NALUnit nalUnit = nalParser.parse(segment);
+
+            if (nalUnit != null) {
+                nalUnits.add(nalUnit);
+            }
+        }
+
+        outputList.add(new DecodedStreamData(nalUnits, pesPacket.getPacketId()));
+
+    }
+
+    private void decodeKlvMetadata(PESPacket pesPacket, List<Object> outputList) {
+        try {
+            outputList.add(new DecodedStreamData(klvParser.parse(pesPacket.getPayload(),
+                    klvDecoder), pesPacket.getPacketId()));
+        } catch (KlvDecodingException e) {
+            LOGGER.warn("unable to decode KLV metadata", e);
+        }
+    }
+
+    public interface KlvParser {
+        DecodedKLVMetadataPacket parse(byte[] pesPacketBytes, KlvDecoder decoder)
+                throws KlvDecodingException;
+    }
+
+    public interface NALReader {
+        ByteBuffer next(ByteBuffer byteBuffer);
+    }
+
+    public interface NALParser {
+        NALUnit parse(ByteBuffer byteBuffer);
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/netty/PacketBuffer.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/netty/PacketBuffer.java
@@ -1,0 +1,388 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.netty;
+
+import static org.apache.commons.lang3.Validate.notNull;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.connexta.alliance.video.stream.mpegts.OutputStreamFactory;
+import com.connexta.alliance.video.stream.mpegts.filename.TempFileGenerator;
+import com.connexta.alliance.video.stream.mpegts.filename.TempFileGeneratorImpl;
+import com.connexta.alliance.video.stream.mpegts.rollover.RolloverCondition;
+
+/**
+ * Buffers raw MPEG-TS packet data and writes the data to a temporary file so that the data
+ * written is on a clean IDR boundary. If an IDR boundary cannot be found, the data will be
+ * eventually flush on a arbitrary point to avoid memory exhaustion. This implementation
+ * is thread-safe.
+ * <p/>
+ * NOTE: This implementation could probably be improved by using some kind of circular buffer with read and write pointers
+ */
+public class PacketBuffer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PacketBuffer.class);
+
+    /**
+     * If we receive an IDR frame followed by an unbounded number of non-IDR frames, then memory
+     * will be exhausted. This limits the frameset size while detecting a complete frameset
+     * when flushing to disk.
+     */
+    private static final long DEFAULT_MAX_FRAMESET_SIZE = 1000;
+
+    /**
+     * The default maximum number of incomplete frame bytes before the data is forcibly
+     * flushed to disk.
+     */
+    private static final long DEFAULT_MAX_INCOMPLETE_FRAME_BYTES = 50000000;
+
+    /**
+     * This is a RolloverCondition that always indicates that the rollover is ready.
+     */
+    private static final RolloverCondition ALWAYS_TRUE = new RolloverCondition() {
+        @Override
+        public boolean isRolloverReady(PacketBuffer packetBuffer) {
+            return true;
+        }
+
+        @Override
+        public void accept(Visitor visitor) {
+
+        }
+    };
+
+    private List<Frame> frames = new ArrayList<>();
+
+    private List<byte[]> incompleteFrame = new ArrayList<>();
+
+    private Lock lock = new ReentrantLock();
+
+    private TempFileGenerator tempFileGenerator = new TempFileGeneratorImpl();
+
+    private File currentTempFile = null;
+
+    private Long tempFileCreateTime = null;
+
+    private long bytesWrittenToTempFile = 0;
+
+    private long incompleteFrameBytes = 0;
+
+    private long maxIncompleteFrameBytes = DEFAULT_MAX_INCOMPLETE_FRAME_BYTES;
+
+    private OutputStreamFactory outputStreamFactory = FileOutputStream::new;
+
+    /**
+     * By default, new Date objects are created by calling {@link Date#Date()}.
+     */
+    private Supplier<Date> dateSupplier = Date::new;
+
+    /**
+     * @param tempFileGenerator must be non-null
+     */
+    public void setTempFileGenerator(TempFileGenerator tempFileGenerator) {
+        notNull(tempFileGenerator, "temFileGenerator must be non-null");
+        this.tempFileGenerator = tempFileGenerator;
+    }
+
+    /**
+     * @param outputStreamFactory must be non-null
+     */
+    public void setOutputStreamFactory(OutputStreamFactory outputStreamFactory) {
+        notNull(outputStreamFactory, "outputStreamFactory must be non-null");
+        this.outputStreamFactory = outputStreamFactory;
+    }
+
+    /**
+     * @param maxIncompleteFrameBytes must be non-null
+     */
+    public void setMaxIncompleteFrameBytes(long maxIncompleteFrameBytes) {
+        notNull(maxIncompleteFrameBytes, "maxIncompleteFrameBytes must be non-null");
+        this.maxIncompleteFrameBytes = maxIncompleteFrameBytes;
+    }
+
+    @Override
+    public String toString() {
+        return "PacketBuffer{" +
+                "bytesWrittenToTempFile=" + bytesWrittenToTempFile +
+                ", incompleteFrameBytes=" + incompleteFrameBytes +
+                '}';
+    }
+
+    /**
+     * Clear all stored data and reset to the initial state.
+     */
+    public void reset() {
+        lock.lock();
+        try {
+            frames.clear();
+            incompleteFrame.clear();
+            currentTempFile = null;
+            tempFileCreateTime = null;
+            bytesWrittenToTempFile = 0;
+            incompleteFrameBytes = 0;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Get the age (milliseconds) of the temporary data file. Returns 0 if there is no file.
+     *
+     * @return age in milliseconds
+     */
+    public long getAge() {
+        lock.lock();
+        try {
+            return tempFileCreateTime == null ?
+                    0 :
+                    dateSupplier.get()
+                            .getTime() - tempFileCreateTime;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Get the number of bytes that have been written to the temporary data file.
+     *
+     * @return bytes
+     */
+    public long getByteCount() {
+        return bytesWrittenToTempFile;
+    }
+
+    /**
+     * Write raw data into the buffer. Empty or null values are handled. If the size of the
+     * incomplete frame data exceeds {@link #maxIncompleteFrameBytes}, then the current
+     * incomplete frame data will be push to the frame list as type {@link FrameType#UNKNOWN}
+     * and a flush to disk will be attempted.
+     *
+     * @param rawPacket may be null or empty
+     */
+    public void write(byte[] rawPacket) {
+        if (rawPacket == null || rawPacket.length == 0) {
+            return;
+        }
+        lock.lock();
+        try {
+            incompleteFrame.add(rawPacket);
+            incompleteFrameBytes += rawPacket.length;
+            if (incompleteFrameBytes > maxIncompleteFrameBytes) {
+                frames.add(new Frame(FrameType.UNKNOWN, incompleteFrame));
+                incompleteFrame = new ArrayList<>();
+                incompleteFrameBytes = 0;
+                flushIfDataAvailable();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Tell the packet buffer that the recently written data represents a complete frame. A flush
+     * to disk will be attempted.
+     *
+     * @param frameType must be non-null
+     */
+    public void frameComplete(FrameType frameType) {
+        notNull(frameType, "frameType must be non-null");
+        lock.lock();
+        try {
+            frames.add(new Frame(frameType, incompleteFrame));
+            incompleteFrame = new ArrayList<>();
+
+            flushIfDataAvailable();
+
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * If a full frameset is in the frame list, then flush the frameset to disk.
+     */
+    private void flushIfDataAvailable() {
+        findLastFramesetIndex().ifPresent((index) -> {
+            try {
+                flushFrameset(index);
+            } catch (IOException e) {
+                LOGGER.warn("unable to write to temp file", e);
+            }
+        });
+    }
+
+    /**
+     * @param index the index of the last frame of the last frameset
+     * @throws IOException
+     */
+    private void flushFrameset(int index) throws IOException {
+
+        try (OutputStream os = outputStreamFactory.create(getTempFile(), true)) {
+
+            List<byte[]> outgoingPackets = frames.subList(0, index + 1)
+                    .stream()
+                    .flatMap(frame -> frame.packets.stream())
+                    .collect(Collectors.toList());
+            frames = new ArrayList<>(frames.subList(index + 1, frames.size()));
+
+            for (byte[] outgoingPacket : outgoingPackets) {
+                os.write(outgoingPacket);
+                bytesWrittenToTempFile += outgoingPacket.length;
+            }
+
+        }
+
+    }
+
+    /**
+     * If the rollover condition is not met, then the method will return {@link Optional#empty()}.
+     * If the rollover condition is met, then the method <b>may</b> return a temp file. The only
+     * reason a temp file may not be returned is when the condition is <code>true</code> even when
+     * no data has been written to file. The caller is responsible for deleting the temp file.
+     *
+     * @param rolloverCondition the rollover condition
+     * @return an optional temp file
+     */
+    public Optional<File> rotate(RolloverCondition rolloverCondition) {
+        lock.lock();
+        try {
+            if (!rolloverCondition.isRolloverReady(this)) {
+                return Optional.empty();
+            }
+            if (currentTempFile == null || bytesWrittenToTempFile == 0) {
+                return Optional.empty();
+            }
+            File tempFile = currentTempFile;
+            currentTempFile = null;
+            bytesWrittenToTempFile = 0;
+            return Optional.of(tempFile);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Flush all buffered data to disk and rotate. Will return {@link Optional#empty()} if no data
+     * has been written to file. The caller is responsible for deleting the temp file.
+     *
+     * @return an optional temp file
+     * @throws IOException
+     */
+    public Optional<File> flushAndRotate() throws IOException {
+        lock.lock();
+        try {
+
+            if (!incompleteFrame.isEmpty()) {
+                frames.add(new Frame(FrameType.UNKNOWN, incompleteFrame));
+                incompleteFrame = new ArrayList<>();
+            }
+
+            if (!frames.isEmpty()) {
+                flushFrameset(frames.size() - 1);
+            }
+
+            return rotate(ALWAYS_TRUE);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private File getTempFile() throws IOException {
+        if (currentTempFile == null) {
+            tempFileCreateTime = dateSupplier.get()
+                    .getTime();
+            bytesWrittenToTempFile = 0;
+            currentTempFile = tempFileGenerator.generate();
+        }
+        return currentTempFile;
+    }
+
+    private Set<FrameType> summarizeFrameTypes() {
+        return frames.stream()
+                .map(frame -> frame.frameType)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Search the frame list for the last frame in a frameset. This can only be detected when the
+     * following occurs: IDR? NON-IDR* IDR. We are never guaranteed to have the leading IDR because
+     * we could start reading a stream in the middle of a frameset. If the frame list only contains
+     * UNKNOWN frame types, then always return the last index of the frame list. If the frame list
+     * contains more than maxFramesetSize, then it is considered to be a complete framset
+     * in order to avoid memory exhaustion.
+     *
+     * @return non-null optional value, may contain index to the last frame in a frameset
+     */
+    private Optional<Integer> findLastFramesetIndex() {
+
+        long maxFramesetSize = DEFAULT_MAX_FRAMESET_SIZE;
+
+        if (frames.size() > maxFramesetSize) {
+            return Optional.of(frames.size() - 1);
+        }
+
+        Set<FrameType> frameTypeSummary = summarizeFrameTypes();
+
+        if (frameTypeSummary.size() == 1 && frameTypeSummary.contains(FrameType.UNKNOWN)) {
+            return Optional.of(frames.size() - 1);
+        }
+
+        if (!frameTypeSummary.contains(FrameType.IDR)) {
+            return Optional.empty();
+        }
+
+        for (int i = frames.size() - 1; i > 0; i--) {
+            if (frames.get(i).frameType == FrameType.IDR) {
+                return Optional.of(i - 1);
+            }
+        }
+        return Optional.empty();
+    }
+
+    public enum FrameType {
+        IDR, NON_IDR, UNKNOWN
+    }
+
+    /**
+     * Contains all of the raw packets associated with a video frame. May contain non-video data
+     * that was intermixed with the video data.
+     */
+    private static class Frame {
+
+        private List<byte[]> packets;
+
+        private FrameType frameType;
+
+        public Frame(FrameType frameType, List<byte[]> packets) {
+            this.frameType = frameType;
+            this.packets = packets;
+        }
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/netty/RawUdpDataToMTSPacketDecoder.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/netty/RawUdpDataToMTSPacketDecoder.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.netty;
+
+import static org.apache.commons.lang3.Validate.notNull;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.taktik.mpegts.MTSPacket;
+import org.taktik.mpegts.sources.MTSSources;
+import org.taktik.mpegts.sources.ResettableMTSSource;
+
+import com.google.common.io.ByteSource;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.handler.codec.MessageToMessageDecoder;
+
+/**
+ * Converts datagrams to a series of MTSPackets. Will discard data while looking for the MPEG-TS
+ * sync byte.
+ */
+class RawUdpDataToMTSPacketDecoder extends MessageToMessageDecoder<DatagramPacket> {
+
+    public static final byte TS_SYNC = (byte) 0x47;
+
+    public static final int BUFFER_SIZE = 4096;
+
+    public static final int TS_PACKET_SIZE = 188;
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(RawUdpDataToMTSPacketDecoder.class);
+
+    private ByteBuf byteBuf;
+
+    private PacketBuffer packetBuffer;
+
+    private MTSParser mtsParser = MTSSources::from;
+
+    public RawUdpDataToMTSPacketDecoder(PacketBuffer packetBuffer) {
+        this.packetBuffer = packetBuffer;
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        if (byteBuf != null) {
+            byteBuf.release();
+        }
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        byteBuf = ctx.alloc()
+                .buffer(BUFFER_SIZE);
+    }
+
+    @Override
+    protected void decode(ChannelHandlerContext ctx, DatagramPacket msg, List<Object> outputList)
+            throws Exception {
+
+        notNull(ctx, "ctx must be non-null");
+        notNull(msg, "msg must be non-null");
+        notNull(outputList, "outputList must be non-null");
+
+        byteBuf.writeBytes(msg.content());
+
+        skipToSyncByte();
+
+        while (byteBuf.readableBytes() >= TS_PACKET_SIZE) {
+
+            byte[] payload = new byte[TS_PACKET_SIZE];
+
+            byteBuf.readBytes(payload);
+
+            ResettableMTSSource src = mtsParser.parse(ByteSource.wrap(payload));
+
+            MTSPacket packet = null;
+            try {
+                packet = src.nextPacket();
+            } catch (IOException e) {
+                LOGGER.warn("unable to parse mpegst packet", e);
+            }
+
+            if (packet != null) {
+                packetBuffer.write(payload);
+                outputList.add(packet);
+            }
+
+            skipToSyncByte();
+        }
+
+        byteBuf.discardReadBytes();
+
+    }
+
+    private void skipToSyncByte() {
+
+        int bytesBefore;
+
+        if ((bytesBefore = byteBuf.bytesBefore(TS_SYNC)) > 0) {
+            LOGGER.info("skipping bytes in raw data stream, looking for MPEG-TS sync {}",
+                    bytesBefore);
+            byteBuf.skipBytes(bytesBefore);
+        }
+
+    }
+
+    public interface MTSParser {
+        ResettableMTSSource parse(ByteSource byteSource) throws IOException;
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/netty/StreamProcessor.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/netty/StreamProcessor.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.netty;
+
+import java.net.URI;
+import java.util.Optional;
+
+public interface StreamProcessor {
+
+    /**
+     * Get the URI of the stream associated with this stream processor.
+     *
+     * @return optional uri of the stream
+     */
+    Optional<URI> getStreamUri();
+
+    /**
+     * Get the title string to be used for the parent metacard.
+     *
+     * @return optional title of the stream
+     */
+    Optional<String> getTitle();
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/netty/UdpStreamProcessor.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/netty/UdpStreamProcessor.java
@@ -1,0 +1,382 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.netty;
+
+import static org.apache.commons.lang3.Validate.inclusiveBetween;
+import static org.apache.commons.lang3.Validate.notNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.apache.commons.lang3.Validate;
+import org.codice.ddf.security.common.Security;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.connexta.alliance.libs.klv.KlvHandler;
+import com.connexta.alliance.libs.klv.KlvHandlerFactory;
+import com.connexta.alliance.libs.klv.KlvProcessor;
+import com.connexta.alliance.libs.klv.Stanag4609Processor;
+import com.connexta.alliance.video.stream.mpegts.StreamMonitor;
+import com.connexta.alliance.video.stream.mpegts.UdpStreamMonitor;
+import com.connexta.alliance.video.stream.mpegts.filename.FilenameGenerator;
+import com.connexta.alliance.video.stream.mpegts.rollover.BooleanOrRolloverCondition;
+import com.connexta.alliance.video.stream.mpegts.rollover.ByteCountRolloverCondition;
+import com.connexta.alliance.video.stream.mpegts.rollover.CatalogRolloverAction;
+import com.connexta.alliance.video.stream.mpegts.rollover.CreateMetacardRolloverAction;
+import com.connexta.alliance.video.stream.mpegts.rollover.ElapsedTimeRolloverCondition;
+import com.connexta.alliance.video.stream.mpegts.rollover.KlvRolloverAction;
+import com.connexta.alliance.video.stream.mpegts.rollover.ListRolloverAction;
+import com.connexta.alliance.video.stream.mpegts.rollover.RolloverAction;
+import com.connexta.alliance.video.stream.mpegts.rollover.RolloverActionException;
+import com.connexta.alliance.video.stream.mpegts.rollover.RolloverCondition;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.data.MetacardType;
+import io.netty.channel.ChannelHandler;
+
+/**
+ *
+ */
+public class UdpStreamProcessor implements StreamProcessor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UdpStreamProcessor.class);
+
+    private static final boolean IS_KLV_PARSING_ENABLED = false;
+
+    private static final long ONE_SECOND = TimeUnit.SECONDS.toMillis(1);
+
+    /**
+     * Number of milliseconds between rollover checks. See {@link Timer#scheduleAtFixedRate(TimerTask, long, long)}.
+     */
+    private static final long ROLLOVER_CHECK_PERIOD = ONE_SECOND;
+
+    /**
+     * Number of milliseconds to wait until first rollover check. See {@link Timer#scheduleAtFixedRate(TimerTask, long, long)}.
+     */
+    private static final long ROLLOVER_CHECK_DELAY = ONE_SECOND;
+
+    private PacketBuffer packetBuffer = new PacketBuffer();
+
+    private Stanag4609Processor stanag4609Processor;
+
+    private Map<String, KlvHandler> klvHandlerMap;
+
+    private KlvHandler defaultKlvHandler;
+
+    private RolloverCondition rolloverCondition;
+
+    private String filenameTemplate;
+
+    private KlvHandlerFactory klvHandlerFactory;
+
+    private FilenameGenerator filenameGenerator;
+
+    private KlvProcessor klvProcessor;
+
+    private Timer timer = new Timer();
+
+    private List<MetacardType> metacardTypeList;
+
+    private RolloverAction rolloverAction;
+
+    private Integer klvLocationSubsampleCount;
+
+    private CatalogFramework catalogFramework;
+
+    private Lock klvHandlerMapLock = new ReentrantLock();
+
+    private StreamMonitor streamMonitor;
+
+    public UdpStreamProcessor(StreamMonitor streamMonitor) {
+        this.streamMonitor = streamMonitor;
+    }
+
+    @Override
+    public Optional<URI> getStreamUri() {
+        return streamMonitor.getStreamUri();
+    }
+
+    @Override
+    public Optional<String> getTitle() {
+        return streamMonitor.getTitle();
+    }
+
+    /**
+     * @param klvLocationSubsampleCount must be non-null and >0
+     */
+    public void setKlvLocationSubsampleCount(Integer klvLocationSubsampleCount) {
+        notNull(klvLocationSubsampleCount, "klvLocationSubsampleCount must be non-null");
+        Validate.inclusiveBetween(UdpStreamMonitor.SUBSAMPLE_COUNT_MIN,
+                UdpStreamMonitor.SUBSAMPLE_COUNT_MAX,
+                klvLocationSubsampleCount,
+                "klvLocationSubsampleCount must be >0");
+        this.klvLocationSubsampleCount = klvLocationSubsampleCount;
+    }
+
+    /**
+     * @param catalogFramework must be non-null
+     */
+    public void setCatalogFramework(CatalogFramework catalogFramework) {
+        notNull(catalogFramework, "catalogFramework must be non-null");
+        this.catalogFramework = catalogFramework;
+    }
+
+    @Override
+    public String toString() {
+        return "UdpStreamProcessor{" +
+                "defaultKlvHandler=" + defaultKlvHandler +
+                ", filenameGenerator=" + filenameGenerator +
+                ", filenameTemplate='" + filenameTemplate + '\'' +
+                ", klvHandlerFactory=" + klvHandlerFactory +
+                ", klvProcessor=" + klvProcessor +
+                ", metacardTypeList=" + metacardTypeList +
+                ", packetBuffer=" + packetBuffer +
+                ", rolloverCondition=" + rolloverCondition +
+                ", stanag4609Processor=" + stanag4609Processor +
+                '}';
+    }
+
+    /**
+     * @param count must be non-null and positive
+     */
+    public void setByteCountRolloverCondition(Integer count) {
+        notNull(count, "count must be non-null");
+        inclusiveBetween(UdpStreamMonitor.BYTE_COUNT_MIN,
+                UdpStreamMonitor.BYTE_COUNT_MAX,
+                count,
+                "count must be >0");
+        rolloverCondition.accept(new RolloverCondition.Visitor() {
+            @Override
+            public void visit(BooleanOrRolloverCondition condition) {
+            }
+
+            @Override
+            public void visit(ElapsedTimeRolloverCondition condition) {
+            }
+
+            @Override
+            public void visit(ByteCountRolloverCondition condition) {
+                condition.setByteCountThreshold(count);
+            }
+        });
+    }
+
+    /**
+     * @param milliseconds must be non-null and positive
+     */
+    public void setElapsedTimeRolloverCondition(Long milliseconds) {
+        notNull(milliseconds, "milliseconds must be non-null");
+        inclusiveBetween(UdpStreamMonitor.ELAPSED_TIME_MIN,
+                UdpStreamMonitor.ELAPSED_TIME_MAX,
+                milliseconds,
+                "milliseconds must be >0");
+        rolloverCondition.accept(new RolloverCondition.Visitor() {
+            @Override
+            public void visit(BooleanOrRolloverCondition condition) {
+            }
+
+            @Override
+            public void visit(ElapsedTimeRolloverCondition condition) {
+                condition.setElapsedTimeThreshold(milliseconds);
+            }
+
+            @Override
+            public void visit(ByteCountRolloverCondition condition) {
+            }
+        });
+    }
+
+    /**
+     * Shutdown the stream processor. Attempts to flush and ingest any partial stream data regardless
+     * of IDR boundaries.
+     */
+    public void shutdown() {
+
+        timer.cancel();
+
+        try {
+            packetBuffer.flushAndRotate()
+                    .ifPresent(this::doRollover);
+        } catch (IOException e) {
+            LOGGER.warn("unable to rotate and ingest final data during shutdown", e);
+        }
+
+        packetBuffer.reset();
+        klvHandlerMap = null;
+    }
+
+    private void checkForRollover() {
+        packetBuffer.rotate(rolloverCondition)
+                .ifPresent(this::doRollover);
+    }
+
+    private void doRollover(File tempFile) {
+        try {
+            rolloverAction.doAction(tempFile);
+        } catch (RolloverActionException e) {
+            LOGGER.warn("unable handle rollover file: tempFile={}", tempFile, e);
+        } finally {
+            if (!tempFile.delete()) {
+                LOGGER.warn("unable to delete temp file: filename={}", tempFile);
+            }
+        }
+    }
+
+    /**
+     * @param metacardTypeList must be non-null
+     */
+    public void setMetacardTypeList(List<MetacardType> metacardTypeList) {
+        notNull(metacardTypeList, "metacardTypeList must be non-null");
+        this.metacardTypeList = metacardTypeList;
+    }
+
+    private TimerTask createTimerTask() {
+        return new TimerTask() {
+            @Override
+            public void run() {
+                checkForRollover();
+            }
+        };
+    }
+
+    private boolean areNonNull(List<Object> listofObjects) {
+        return listofObjects.stream()
+                .allMatch(Objects::nonNull);
+    }
+
+    /**
+     * Return <code>true</code> if the processor is ready to run.
+     *
+     * @return ready status
+     */
+    public boolean isReady() {
+        return areNonNull(Arrays.asList(stanag4609Processor,
+                defaultKlvHandler,
+                rolloverCondition,
+                filenameTemplate,
+                klvHandlerFactory,
+                filenameGenerator,
+                klvProcessor,
+                metacardTypeList,
+                catalogFramework));
+    }
+
+    /**
+     * Initializes the processor. Users should call {@link #isReady()} first to make sure the
+     * processor is ready to run.
+     */
+    public void init() {
+
+        klvHandlerMap = klvHandlerFactory.createStanag4609Handlers();
+
+        rolloverAction = new ListRolloverAction(Arrays.asList(new CreateMetacardRolloverAction(
+                        metacardTypeList),
+                new KlvRolloverAction(klvHandlerMap,
+                        klvHandlerMapLock,
+                        klvLocationSubsampleCount,
+                        klvProcessor),
+                new CatalogRolloverAction(filenameGenerator,
+                        filenameTemplate,
+                        this,
+                        catalogFramework,
+                        Security.getInstance(),
+                        metacardTypeList)));
+
+        timer.scheduleAtFixedRate(createTimerTask(), ROLLOVER_CHECK_DELAY, ROLLOVER_CHECK_PERIOD);
+    }
+
+    /**
+     * @param klvHandlerFactory must be non-null
+     */
+    public void setKlvHandlerFactory(KlvHandlerFactory klvHandlerFactory) {
+        notNull(klvHandlerFactory, "klvHandlerFactory must be non-null");
+        this.klvHandlerFactory = klvHandlerFactory;
+    }
+
+    /**
+     * @param klvProcessor must be non-null
+     */
+    public void setKlvProcessor(KlvProcessor klvProcessor) {
+        notNull(klvProcessor, "klvProcessor must be non-null");
+        this.klvProcessor = klvProcessor;
+    }
+
+    /**
+     * @param filenameGenerator must be non-null
+     */
+    public void setFilenameGenerator(FilenameGenerator filenameGenerator) {
+        notNull(filenameGenerator, "filenameGenerator must be non-null");
+        this.filenameGenerator = filenameGenerator;
+    }
+
+    /**
+     * @param filenameTemplate must be non-null
+     */
+    public void setFilenameTemplate(String filenameTemplate) {
+        notNull(filenameTemplate, "filenameTemplate must be non-null");
+        this.filenameTemplate = filenameTemplate;
+    }
+
+    /**
+     * @param rolloverCondition must be non-null
+     */
+    public void setRolloverCondition(RolloverCondition rolloverCondition) {
+        notNull(rolloverCondition, "rolloverCondition must be non-null");
+        this.rolloverCondition = rolloverCondition;
+    }
+
+    /**
+     * @param defaultKlvHandler must be non-null
+     */
+    public void setDefaultKlvHandler(KlvHandler defaultKlvHandler) {
+        notNull(defaultKlvHandler, "defaultKlvHandler must be non-null");
+        this.defaultKlvHandler = defaultKlvHandler;
+    }
+
+    /**
+     * @param stanag4609Processor must be non-null
+     */
+    public void setStanag4609Processor(Stanag4609Processor stanag4609Processor) {
+        notNull(stanag4609Processor, "stanage4609Processor must be non-null");
+        this.stanag4609Processor = stanag4609Processor;
+    }
+
+    /**
+     * Returns an array of ChannelHandler objects used by Netty as the pipeline.
+     *
+     * @return non-null array of channel handlers
+     */
+    public ChannelHandler[] createChannelHandlers() {
+        return new ChannelHandler[] {new RawUdpDataToMTSPacketDecoder(packetBuffer),
+                new MTSPacketToPESPacketDecoder(), new PESPacketToApplicationDataDecoder(
+                IS_KLV_PARSING_ENABLED), new DecodedStreamDataHandler(packetBuffer,
+                stanag4609Processor,
+                klvHandlerMap,
+                defaultKlvHandler,
+                klvHandlerMapLock)};
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/rollover/BaseRolloverAction.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/rollover/BaseRolloverAction.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.rollover;
+
+import java.io.File;
+
+import ddf.catalog.data.impl.MetacardImpl;
+
+abstract class BaseRolloverAction implements RolloverAction {
+
+    @Override
+    public final MetacardImpl doAction(File tempFile) throws RolloverActionException {
+        return doAction(null, tempFile);
+    }
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/rollover/BooleanOrRolloverCondition.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/rollover/BooleanOrRolloverCondition.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.rollover;
+
+import static org.apache.commons.lang3.Validate.notNull;
+
+import com.connexta.alliance.video.stream.mpegts.netty.PacketBuffer;
+
+/**
+ * Compute the boolean-or of two RolloverCondition objects.
+ */
+public class BooleanOrRolloverCondition implements RolloverCondition {
+
+    private final RolloverCondition firstCondition;
+
+    private final RolloverCondition secondCondition;
+
+    /**
+     * @param firstCondition  must be non-null
+     * @param secondCondition must be non-null
+     */
+    public BooleanOrRolloverCondition(RolloverCondition firstCondition,
+            RolloverCondition secondCondition) {
+        notNull(firstCondition, "firstCondition must be non-null");
+        notNull(secondCondition, "secondCondition must be non-null");
+
+        this.firstCondition = firstCondition;
+        this.secondCondition = secondCondition;
+    }
+
+    @Override
+    public boolean isRolloverReady(PacketBuffer packetBuffer) {
+        notNull(packetBuffer, "packetBuffer must be non-null");
+
+        return this.firstCondition.isRolloverReady(packetBuffer)
+                || this.secondCondition.isRolloverReady(packetBuffer);
+    }
+
+    @Override
+    public void accept(Visitor visitor) {
+        notNull(visitor, "visitor must be non-null");
+
+        firstCondition.accept(visitor);
+        visitor.visit(this);
+        secondCondition.accept(visitor);
+    }
+
+    @Override
+    public String toString() {
+        return "BooleanOrRolloverCondition{" +
+                "firstCondition=" + firstCondition +
+                ", secondCondition=" + secondCondition +
+                '}';
+    }
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/rollover/ByteCountRolloverCondition.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/rollover/ByteCountRolloverCondition.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.rollover;
+
+import static org.apache.commons.lang3.Validate.notNull;
+
+import com.connexta.alliance.video.stream.mpegts.netty.PacketBuffer;
+
+/**
+ * Test to determine if {@link PacketBuffer#getByteCount()} ()} is greater than or equal to a specific
+ * threshold.
+ */
+public class ByteCountRolloverCondition implements RolloverCondition {
+
+    private long byteCountThreshold;
+
+    public ByteCountRolloverCondition(long byteCountThreshold) {
+        this.byteCountThreshold = byteCountThreshold;
+    }
+
+    public long getByteCountThreshold() {
+        return byteCountThreshold;
+    }
+
+    public void setByteCountThreshold(long byteCountThreshold) {
+        this.byteCountThreshold = byteCountThreshold;
+    }
+
+    @Override
+    public boolean isRolloverReady(PacketBuffer packetBuffer) {
+        notNull(packetBuffer, "packetBuffer must be non-null");
+        return packetBuffer.getByteCount() >= byteCountThreshold;
+    }
+
+    @Override
+    public void accept(Visitor visitor) {
+        notNull(visitor, "visitor must be non-null");
+        visitor.visit(this);
+    }
+
+    @Override
+    public String toString() {
+        return "ByteCountRolloverCondition{" +
+                "byteCountThreshold=" + byteCountThreshold +
+                '}';
+    }
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/rollover/CatalogRolloverAction.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/rollover/CatalogRolloverAction.java
@@ -1,0 +1,368 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.rollover;
+
+import static org.apache.commons.lang3.Validate.notNull;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.shiro.util.ThreadContext;
+import org.codice.ddf.security.common.Security;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.connexta.alliance.video.stream.mpegts.Constants;
+import com.connexta.alliance.video.stream.mpegts.filename.FilenameGenerator;
+import com.connexta.alliance.video.stream.mpegts.metacard.FrameCenterMetacardUpdater;
+import com.connexta.alliance.video.stream.mpegts.metacard.ListMetacardUpdater;
+import com.connexta.alliance.video.stream.mpegts.metacard.LocationMetacardUpdater;
+import com.connexta.alliance.video.stream.mpegts.metacard.MetacardUpdater;
+import com.connexta.alliance.video.stream.mpegts.metacard.ModifiedDateMetacardUpdater;
+import com.connexta.alliance.video.stream.mpegts.metacard.TemporalEndMetacardUpdater;
+import com.connexta.alliance.video.stream.mpegts.metacard.TemporalStartMetacardUpdater;
+import com.connexta.alliance.video.stream.mpegts.netty.StreamProcessor;
+import com.google.common.io.ByteSource;
+import com.google.common.io.Files;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.content.data.ContentItem;
+import ddf.catalog.content.data.impl.ContentItemImpl;
+import ddf.catalog.content.operation.CreateStorageRequest;
+import ddf.catalog.content.operation.impl.CreateStorageRequestImpl;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardCreationException;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.operation.CreateRequest;
+import ddf.catalog.operation.CreateResponse;
+import ddf.catalog.operation.Update;
+import ddf.catalog.operation.UpdateRequest;
+import ddf.catalog.operation.impl.CreateRequestImpl;
+import ddf.catalog.operation.impl.UpdateRequestImpl;
+import ddf.catalog.source.IngestException;
+import ddf.catalog.source.SourceUnavailableException;
+import ddf.security.SubjectUtils;
+
+/**
+ * Creates the parent metacard that represents
+ * the stream, stores the child content, links the child to the parent, and updates the parent's
+ * location with the union of the child's location.
+ */
+public class CatalogRolloverAction extends BaseRolloverAction {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CatalogRolloverAction.class);
+
+    private static final long MAX_RETRY_MILLISECONDS = TimeUnit.MINUTES.toMillis(5);
+
+    private static final long INITIAL_RETRY_WAIT_MILLISECONDS = TimeUnit.MILLISECONDS.toMillis(500);
+
+    private final FilenameGenerator filenameGenerator;
+
+    private final StreamProcessor streamProcessor;
+
+    private final CatalogFramework catalogFramework;
+
+    private final Security security;
+
+    private final List<MetacardType> metacardTypeList;
+
+    private String filenameTemplate;
+
+    private Metacard parentMetacard;
+
+    private MetacardUpdater parentMetacardUpdater =
+            new ListMetacardUpdater(Arrays.asList(new LocationMetacardUpdater(),
+                    new TemporalStartMetacardUpdater(),
+                    new TemporalEndMetacardUpdater(),
+                    new ModifiedDateMetacardUpdater(),
+                    new FrameCenterMetacardUpdater()));
+
+    /**
+     * @param filenameGenerator must be non-null
+     * @param filenameTemplate  must be non-null
+     * @param streamProcessor   must be non-null
+     * @param catalogFramework  must be non-null
+     * @param security          must be non-null
+     * @param metacardTypeList  must be non-null
+     */
+    public CatalogRolloverAction(FilenameGenerator filenameGenerator, String filenameTemplate,
+            StreamProcessor streamProcessor, CatalogFramework catalogFramework, Security security,
+            List<MetacardType> metacardTypeList) {
+        notNull(filenameGenerator, "filenameGenerator must be non-null");
+        notNull(filenameTemplate, "filenameTemplate must be non-null");
+        notNull(streamProcessor, "streamProcessor must be non-null");
+        notNull(catalogFramework, "catalogFramework must be non-null");
+        notNull(security, "security must be non-null");
+        notNull(metacardTypeList, "metacardTypeList must be non-null");
+
+        this.filenameGenerator = filenameGenerator;
+        this.filenameTemplate = filenameTemplate;
+        this.streamProcessor = streamProcessor;
+        this.catalogFramework = catalogFramework;
+        this.security = security;
+        this.metacardTypeList = metacardTypeList;
+    }
+
+    @Override
+    public String toString() {
+        return "CatalogRolloverAction{" +
+                "catalogFramework=" + catalogFramework +
+                ", filenameTemplate='" + filenameTemplate + '\'' +
+                ", filenameGenerator=" + filenameGenerator +
+                ", metacardTypeList=" + metacardTypeList +
+                '}';
+    }
+
+    @Override
+    public MetacardImpl doAction(MetacardImpl metacard, File tempFile)
+            throws RolloverActionException {
+
+        bindSecuritySubject();
+
+        String fileName = generateFilename();
+
+        enforceRequiredMetacardFields(metacard, fileName);
+
+        createParentMetacard();
+
+        ContentItem contentItem = createContentItem(metacard,
+                fileName,
+                Files.asByteSource(tempFile));
+
+        CreateStorageRequest createStorageRequest = createStorageRequest(contentItem);
+
+        CreateResponse createResponse = submitStorageCreateRequest(createStorageRequest);
+
+        for (Metacard childMetacard : createResponse.getCreatedMetacards()) {
+            LOGGER.info("created catalog content with id={}", childMetacard.getId());
+
+            linkChildToParent(childMetacard);
+
+            updateParentWithChildMetadata(childMetacard);
+
+        }
+
+        return metacard;
+    }
+
+    private String generateFilename() {
+        return filenameGenerator.generateFilename(filenameTemplate);
+    }
+
+    private void updateParentWithChildMetadata(Metacard childMetacard)
+            throws RolloverActionException {
+        parentMetacardUpdater.update(parentMetacard, childMetacard);
+        UpdateRequest updateRequest = createUpdateRequest(parentMetacard.getId(), parentMetacard);
+        submitParentUpdateRequest(updateRequest);
+    }
+
+    private void submitParentUpdateRequest(UpdateRequest updateRequest)
+            throws RolloverActionException {
+        submitUpdateRequestWithRetry(updateRequest, update -> {
+            LOGGER.info("updated parent metacard: newMetacard={}",
+                    update.getNewMetacard()
+                            .getId());
+            parentMetacard = update.getNewMetacard();
+        });
+    }
+
+    private void submitChildUpdateRequest(UpdateRequest updateRequest)
+            throws RolloverActionException {
+        submitUpdateRequestWithRetry(updateRequest,
+                update -> LOGGER.info("updated child metacard with link to parent: child={}",
+                        update.getNewMetacard()
+                                .getId()));
+    }
+
+    private void submitUpdateRequestWithRetry(UpdateRequest updateRequest,
+            Consumer<Update> updateConsumer) throws RolloverActionException {
+
+        long wait = INITIAL_RETRY_WAIT_MILLISECONDS;
+        long start = System.currentTimeMillis();
+
+        while (true) {
+            try {
+                submitUpdateRequest(updateRequest, updateConsumer);
+                return;
+            } catch (RolloverActionException e) {
+                if ((System.currentTimeMillis() - start) > MAX_RETRY_MILLISECONDS) {
+                    throw e;
+                } else {
+                    LOGGER.warn("failed to update catalog, will retry in {} milliseconds", wait);
+                    try {
+                        Thread.sleep(wait);
+                    } catch (InterruptedException e1) {
+                        LOGGER.warn("interrupted while waiting to retry update request", e1);
+                        Thread.interrupted();
+                        return;
+                    }
+                    long timeRemaining =
+                            MAX_RETRY_MILLISECONDS - (System.currentTimeMillis() - start);
+                    wait = Math.min(wait * 2, timeRemaining);
+                }
+            }
+        }
+    }
+
+    private void submitUpdateRequest(UpdateRequest updateRequest, Consumer<Update> updateConsumer)
+            throws RolloverActionException {
+        try {
+            catalogFramework.update(updateRequest)
+                    .getUpdatedMetacards()
+                    .forEach(updateConsumer);
+        } catch (IngestException | SourceUnavailableException e) {
+            throw new RolloverActionException(String.format(
+                    "unable to submit update request to catalog framework: updateRequest=%s",
+                    updateRequest), e);
+        }
+    }
+
+    private UpdateRequest createUpdateRequest(String id, Metacard metacard) {
+        return new UpdateRequestImpl(id, metacard);
+    }
+
+    private void linkChildToParent(Metacard childMetacard) throws RolloverActionException {
+        setDerivedAttribute(childMetacard);
+
+        UpdateRequest updateChild = createUpdateRequest(childMetacard.getId(), childMetacard);
+
+        submitChildUpdateRequest(updateChild);
+    }
+
+    private void setDerivedAttribute(Metacard childMetacard) {
+        childMetacard.setAttribute(new AttributeImpl(Metacard.DERIVED, parentMetacard.getId()));
+    }
+
+    private CreateResponse submitStorageCreateRequest(CreateStorageRequest createRequest)
+            throws RolloverActionException {
+        try {
+            return catalogFramework.create(createRequest);
+        } catch (IngestException | SourceUnavailableException e) {
+            throw new RolloverActionException(String.format(
+                    "unable to submit storage create request to catalog framework: %s",
+                    createRequest), e);
+        }
+    }
+
+    private CreateStorageRequest createStorageRequest(ContentItem contentItem) {
+        return new CreateStorageRequestImpl(Collections.singletonList(contentItem),
+                new HashMap<>());
+    }
+
+    private void bindSecuritySubject() {
+        ThreadContext.bind(security.getSystemSubject());
+    }
+
+    private ContentItem createContentItem(MetacardImpl metacard, String fileName,
+            ByteSource byteSource) {
+        return new ContentItemImpl(byteSource, Constants.MPEGTS_MIME_TYPE, fileName, metacard);
+    }
+
+    private void createParentMetacard() throws RolloverActionException {
+        try {
+            createParentIfUnset();
+        } catch (MetacardCreationException | SourceUnavailableException | IngestException e) {
+            throw new RolloverActionException(String.format(
+                    "unable to create parent metacard: sourceUri=%s",
+                    streamProcessor.getStreamUri()), e);
+        }
+    }
+
+    private void createParentIfUnset()
+            throws MetacardCreationException, SourceUnavailableException, IngestException {
+        if (parentMetacard == null) {
+            MetacardImpl metacard = createInitialMetacard();
+
+            setParentResourceUri(metacard);
+            setParentTitle(metacard);
+            setParentContentType(metacard);
+
+            CreateRequest createRequest = new CreateRequestImpl(metacard);
+
+            submitParentCreateRequest(createRequest);
+
+        }
+    }
+
+    private void submitParentCreateRequest(CreateRequest createRequest)
+            throws IngestException, SourceUnavailableException {
+        catalogFramework.create(createRequest)
+                .getCreatedMetacards()
+                .forEach(createdMetacard -> {
+                    LOGGER.info("created parent metacard: metacard={}", createdMetacard.getId());
+                    parentMetacard = createdMetacard;
+                });
+    }
+
+    private void setParentResourceUri(MetacardImpl metacard) {
+        streamProcessor.getStreamUri()
+                .ifPresent(metacard::setResourceURI);
+    }
+
+    private void setParentContentType(MetacardImpl metacard) {
+        metacard.setContentTypeName(Constants.MPEGTS_MIME_TYPE);
+    }
+
+    private void setParentTitle(MetacardImpl metacard) {
+        streamProcessor.getTitle()
+                .ifPresent(metacard::setTitle);
+    }
+
+    private MetacardImpl createInitialMetacard() throws MetacardCreationException {
+        return new MetacardImpl(metacardTypeList.stream()
+                .findFirst()
+                .orElseThrow(() -> new MetacardCreationException("unable to find a metacard type")));
+    }
+
+    private void enforceRequiredMetacardFields(MetacardImpl metacard, String fileName) {
+        if (metacard != null) {
+            setIdAttribute(metacard);
+
+            setTitleAttribute(metacard, fileName);
+
+            setPointOfContactAttribute(metacard);
+        }
+    }
+
+    private void setPointOfContactAttribute(MetacardImpl metacard) {
+        String subjectName = SubjectUtils.getName(security.getSystemSubject());
+
+        metacard.setAttribute(new AttributeImpl(Metacard.POINT_OF_CONTACT,
+                subjectName == null ? "" : subjectName));
+    }
+
+    private void setTitleAttribute(MetacardImpl metacard, String fileName) {
+        if (StringUtils.isBlank(metacard.getTitle())) {
+            metacard.setTitle(fileName);
+        }
+    }
+
+    private void setIdAttribute(MetacardImpl metacard) {
+        if (metacard.getId() == null) {
+            metacard.setId(UUID.randomUUID()
+                    .toString()
+                    .replaceAll("-", ""));
+        }
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/rollover/CreateMetacardRolloverAction.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/rollover/CreateMetacardRolloverAction.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.rollover;
+
+import java.io.File;
+import java.util.List;
+
+import com.connexta.alliance.video.stream.mpegts.Constants;
+
+import ddf.catalog.data.MetacardCreationException;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.MetacardImpl;
+
+public class CreateMetacardRolloverAction extends BaseRolloverAction {
+
+    private List<MetacardType> metacardTypeList;
+
+    public CreateMetacardRolloverAction(List<MetacardType> metacardTypeList) {
+        this.metacardTypeList = metacardTypeList;
+    }
+
+    @Override
+    public MetacardImpl doAction(MetacardImpl metacard, File tempFile)
+            throws RolloverActionException {
+
+        MetacardImpl newMetacard;
+        try {
+            newMetacard = new MetacardImpl(findMetacardType());
+        } catch (MetacardCreationException e) {
+            throw new RolloverActionException(String.format("unable to create metacard: tempFile=%s",
+                    tempFile), e);
+        }
+        newMetacard.setContentTypeName(Constants.MPEGTS_MIME_TYPE);
+
+        return newMetacard;
+    }
+
+    private MetacardType findMetacardType() throws MetacardCreationException {
+        return metacardTypeList.stream()
+                .findFirst()
+                .orElseThrow(() -> new MetacardCreationException("no metacard type found!"));
+    }
+
+    @Override
+    public String toString() {
+        return "CreateMetacardRolloverAction{" +
+                "metacardTypeList=" + metacardTypeList +
+                '}';
+    }
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/rollover/ElapsedTimeRolloverCondition.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/rollover/ElapsedTimeRolloverCondition.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.rollover;
+
+import static org.apache.commons.lang3.Validate.notNull;
+
+import com.connexta.alliance.video.stream.mpegts.netty.PacketBuffer;
+
+/**
+ * Test to determine if {@link PacketBuffer#getAge()} is greater than or equal to a specific
+ * threshold.
+ */
+public class ElapsedTimeRolloverCondition implements RolloverCondition {
+
+    private long elapsedTimeThreshold;
+
+    /**
+     * @param elapsedTimeThreshold milliseconds
+     */
+    public ElapsedTimeRolloverCondition(long elapsedTimeThreshold) {
+        this.elapsedTimeThreshold = elapsedTimeThreshold;
+    }
+
+    public long getElapsedTimeThreshold() {
+        return elapsedTimeThreshold;
+    }
+
+    public void setElapsedTimeThreshold(long elapsedTimeThreshold) {
+        this.elapsedTimeThreshold = elapsedTimeThreshold;
+    }
+
+    @Override
+    public boolean isRolloverReady(PacketBuffer packetBuffer) {
+        notNull(packetBuffer, "packetBuffer must be non-null");
+        return packetBuffer.getAge() >= elapsedTimeThreshold;
+    }
+
+    @Override
+    public void accept(Visitor visitor) {
+        notNull(visitor, "visitor must be non-null");
+        visitor.visit(this);
+    }
+
+    @Override
+    public String toString() {
+        return "ElapsedTimeRolloverCondition{" +
+                "elapsedTimeThreshold=" + elapsedTimeThreshold +
+                '}';
+    }
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/rollover/KlvRolloverAction.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/rollover/KlvRolloverAction.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.rollover;
+
+import java.io.File;
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+
+import com.connexta.alliance.libs.klv.KlvHandler;
+import com.connexta.alliance.libs.klv.KlvProcessor;
+
+import ddf.catalog.data.impl.MetacardImpl;
+
+public class KlvRolloverAction extends BaseRolloverAction {
+
+    private Integer klvLocationSubsampleCount;
+
+    private Lock klvHandlerMapLock;
+
+    private KlvProcessor klvProcessor;
+
+    private Map<String, KlvHandler> klvHandlerMap;
+
+    public KlvRolloverAction(Map<String, KlvHandler> klvHandlerMap, Lock klvHandlerMapLock,
+            Integer klvLocationSubsampleCount, KlvProcessor klvProcessor) {
+        this.klvHandlerMap = klvHandlerMap;
+        this.klvHandlerMapLock = klvHandlerMapLock;
+        this.klvLocationSubsampleCount = klvLocationSubsampleCount;
+        this.klvProcessor = klvProcessor;
+    }
+
+    @Override
+    public MetacardImpl doAction(MetacardImpl metacard, File tempFile)
+            throws RolloverActionException {
+        KlvProcessor.Configuration klvProcessConfiguration = new KlvProcessor.Configuration();
+        klvProcessConfiguration.set(KlvProcessor.Configuration.SUBSAMPLE_COUNT,
+                klvLocationSubsampleCount);
+
+        klvHandlerMapLock.lock();
+        try {
+            klvProcessor.process(klvHandlerMap, metacard, klvProcessConfiguration);
+
+            klvHandlerMap.values()
+                    .forEach(KlvHandler::reset);
+        } finally {
+            klvHandlerMapLock.unlock();
+        }
+
+        return metacard;
+    }
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/rollover/ListRolloverAction.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/rollover/ListRolloverAction.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.rollover;
+
+import java.io.File;
+import java.util.List;
+
+import ddf.catalog.data.impl.MetacardImpl;
+
+/**
+ * Chains a list of RolloverAction objects together.
+ */
+public class ListRolloverAction extends BaseRolloverAction {
+
+    private List<RolloverAction> actionList;
+
+    public ListRolloverAction(List<RolloverAction> actionList) {
+        this.actionList = actionList;
+    }
+
+    @Override
+    public MetacardImpl doAction(MetacardImpl metacard, File tempFile)
+            throws RolloverActionException {
+        MetacardImpl tmp = metacard;
+
+        for (RolloverAction rolloverAction : actionList) {
+            tmp = rolloverAction.doAction(tmp, tempFile);
+        }
+
+        return tmp;
+    }
+
+    @Override
+    public String toString() {
+        return "ListRolloverAction{" +
+                "actionList=" + actionList +
+                '}';
+    }
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/rollover/RolloverAction.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/rollover/RolloverAction.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.rollover;
+
+import java.io.File;
+
+import ddf.catalog.data.impl.MetacardImpl;
+
+public interface RolloverAction {
+
+    /**
+     * Populate a metacard (if non-null) and return a new metacard (may be the same metacard).
+     *
+     * @param metacard the metacard being populated
+     * @param tempFile the temp file that contain content
+     * @return a new metacard or the same metacard
+     * @throws RolloverActionException
+     */
+    MetacardImpl doAction(MetacardImpl metacard, File tempFile) throws RolloverActionException;
+
+    /**
+     * Return a new metacard.
+     *
+     * @param tempFile the temp file that contain content
+     * @return a new metacard or the same metacard
+     * @throws RolloverActionException
+     */
+    MetacardImpl doAction(File tempFile) throws RolloverActionException;
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/rollover/RolloverActionException.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/rollover/RolloverActionException.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.rollover;
+
+public class RolloverActionException extends Exception {
+    public RolloverActionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/rollover/RolloverCondition.java
+++ b/catalog/video/catalog-mpegts-stream/src/main/java/com/connexta/alliance/video/stream/mpegts/rollover/RolloverCondition.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.rollover;
+
+import com.connexta.alliance.video.stream.mpegts.netty.PacketBuffer;
+
+/**
+ * Checks a PacketBuffer to determine if a rollover is desired.
+ */
+public interface RolloverCondition {
+
+    /**
+     * @param packetBuffer must be non-null
+     * @return true if rollover is indicated
+     */
+    boolean isRolloverReady(PacketBuffer packetBuffer);
+
+    /**
+     * @param visitor must be non-null
+     */
+    void accept(Visitor visitor);
+
+    interface Visitor {
+
+        /**
+         * @param condition must be non-null
+         */
+        void visit(BooleanOrRolloverCondition condition);
+
+        /**
+         * @param condition must be non-null
+         */
+        void visit(ElapsedTimeRolloverCondition condition);
+
+        /**
+         * @param condition must be non-null
+         */
+        void visit(ByteCountRolloverCondition condition);
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/video/catalog-mpegts-stream/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/**
+ * Copyright (c) Connexta, LLC
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
+           http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+           http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0
+           http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd">
+
+    <reference-list id="metacardTypeList" interface="ddf.catalog.data.MetacardType" filter="(name=MpegTsMetacardType)" availability="mandatory" />
+
+    <reference id="catalogFramework" interface="ddf.catalog.CatalogFramework"/>
+
+    <cm:managed-service-factory
+            id="videoMpegtsStream"
+            factory-pid="com.connexta.alliance.video.stream.mpegts.UdpStreamMonitor"
+            interface="com.connexta.alliance.video.stream.mpegts.UdpStreamMonitor">
+        <cm:managed-component class="com.connexta.alliance.video.stream.mpegts.UdpStreamMonitor"
+                              init-method="init" destroy-method="destroy">
+
+            <property name="rolloverCondition">
+                <bean class="com.connexta.alliance.video.stream.mpegts.rollover.BooleanOrRolloverCondition">
+                    <argument>
+                        <bean class="com.connexta.alliance.video.stream.mpegts.rollover.ByteCountRolloverCondition">
+                            <argument value="10000000"/>
+                        </bean>
+                    </argument>
+                    <argument>
+                        <bean class="com.connexta.alliance.video.stream.mpegts.rollover.ElapsedTimeRolloverCondition">
+                            <argument value="60000"/>
+                        </bean>
+                    </argument>
+                </bean>
+            </property>
+
+            <property name="filenameGenerator">
+                <bean class="com.connexta.alliance.video.stream.mpegts.filename.ListFilenameGenerator">
+                    <argument>
+                        <list>
+                            <bean class="com.connexta.alliance.video.stream.mpegts.filename.FileExtensionFilenameGenerator">
+                                <argument value="ts"/>
+                            </bean>
+                            <bean class="com.connexta.alliance.video.stream.mpegts.filename.DateTemplateFilenameGenerator"/>
+                            <bean class="com.connexta.alliance.video.stream.mpegts.filename.IllegalCharactersFilenameGenerator"/>
+                        </list>
+                    </argument>
+                </bean>
+            </property>
+
+            <property name="stanag4609Processor">
+                <bean class="com.connexta.alliance.libs.klv.Stanag4609ProcessorImpl">
+                    <argument>
+                        <bean class="com.connexta.alliance.libs.klv.OffsetCenterPostProcessor"/>
+                    </argument>
+                </bean>
+            </property>
+
+            <property name="klvHandlerFactory">
+                <bean class="com.connexta.alliance.libs.klv.KlvHandlerFactoryImpl"/>
+            </property>
+
+            <property name="defaultKlvHandler">
+                <bean class="com.connexta.alliance.libs.klv.LoggingKlvHandler"/>
+            </property>
+
+            <property name="klvProcessor">
+                <bean class="com.connexta.alliance.libs.klv.ListKlvProcessor">
+                    <argument>
+                        <list>
+                            <bean class="com.connexta.alliance.libs.klv.LocationKlvProcessor"/>
+                            <bean class="com.connexta.alliance.libs.klv.SetDatesKlvProcessor"/>
+                            <bean class="com.connexta.alliance.libs.klv.MissionIdKlvProcessor"/>
+                            <bean class="com.connexta.alliance.libs.klv.PlatformDesignationKlvProcessor"/>
+                            <bean class="com.connexta.alliance.libs.klv.ImageSourceSensorKlvProcessor"/>
+                            <bean class="com.connexta.alliance.libs.klv.ObjectCountryCodesKlvProcessor"/>
+                            <bean class="com.connexta.alliance.libs.klv.SecurityClassificationKlvProcessor"/>
+                            <bean class="com.connexta.alliance.libs.klv.FrameCenterKlvProcessor"/>
+                            <bean class="com.connexta.alliance.libs.klv.ClassifyingCountryKlvProcessor"/>
+                        </list>
+                    </argument>
+                </bean>
+            </property>
+
+            <property name="metacardTypeList" ref="metacardTypeList"/>
+
+            <property name="catalogFramework" ref="catalogFramework"/>
+
+            <cm:managed-properties persistent-id=""
+                                   update-strategy="component-managed"
+                                   update-method="updateCallback"/>
+
+        </cm:managed-component>
+
+    </cm:managed-service-factory>
+
+</blueprint>

--- a/catalog/video/catalog-mpegts-stream/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/video/catalog-mpegts-stream/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Connexta, LLC
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ -->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+    <OCD name="MPEG-TS UDP Stream Monitor"
+         id="com.connexta.alliance.video.stream.mpegts.UdpStreamMonitor">
+
+        <AD
+                description="Title of the parent metacard"
+                name="Title" id="parentTitle" required="true"
+                type="String" default="MPEG-TS UDP Stream"/>
+
+        <AD
+                description="Specifies the network address (eg. x.y.z.w or hostname) to be monitored. The address must be resolvable."
+                name="Network Address" id="monitoredAddress" required="true"
+                type="String" default="127.0.0.1"/>
+
+        <AD
+                description="Specifies the network port to be monitored. The port must be >=1 and <=65535."
+                name="Network Port" id="monitoredPort" required="true"
+                type="Integer" default="50000"/>
+
+        <AD
+                description="Maximum file size before rollover. Must be >=1."
+                name="Max File Size" id="byteCountRolloverCondition" required="false"
+                type="Integer" default="10000000" />
+
+        <AD
+                description="Maximum elapsed time in milliseconds before rollover. Must be >=1."
+                name="Max Elapsed Time" id="elapsedTimeRolloverCondition" required="false"
+                type="Long" default="60000" />
+
+        <AD
+                description="Filename template for each chunk. The template may contain any numberof of the sequence '%{date=FORMAT}' where FORMAT is a Java SimpleDateFormat. Must be non-blank."
+                name="Filename Template" id="filenameTemplate" required="true"
+                type="String" default="mpegts-stream-%{date=yyyy-MM-dd_hh:mm:ss}" />
+
+        <AD
+                description="KLV Metadata Location Subsample Count"
+                name="Location Subsample Count" id="klvLocationSubsampleCount" required="true"
+                type="Integer" default="50" />
+
+    </OCD>
+
+    <Designate pid="com.connexta.alliance.video.stream.mpegts.UdpStreamMonitor"
+               factoryPid="com.connexta.alliance.video.stream.mpegts.UdpStreamMonitor">
+        <Object ocdref="com.connexta.alliance.video.stream.mpegts.UdpStreamMonitor"/>
+    </Designate>
+
+</metatype:MetaData>

--- a/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/TestUdpStreamMonitor.java
+++ b/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/TestUdpStreamMonitor.java
@@ -1,0 +1,268 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.connexta.alliance.libs.klv.KlvHandler;
+import com.connexta.alliance.libs.klv.KlvHandlerFactory;
+import com.connexta.alliance.libs.klv.KlvProcessor;
+import com.connexta.alliance.libs.klv.Stanag4609Processor;
+import com.connexta.alliance.video.stream.mpegts.filename.FilenameGenerator;
+import com.connexta.alliance.video.stream.mpegts.netty.UdpStreamProcessor;
+import com.connexta.alliance.video.stream.mpegts.rollover.RolloverCondition;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.data.MetacardType;
+
+public class TestUdpStreamMonitor {
+
+    private UdpStreamProcessor udpStreamProcessor;
+
+    private UdpStreamMonitor udpStreamMonitor;
+
+    @Before
+    public void setup() {
+        udpStreamProcessor = mock(UdpStreamProcessor.class);
+        udpStreamMonitor = new UdpStreamMonitor(udpStreamProcessor);
+    }
+
+    @Test
+    public void testSetElapsedTimeRolloverCondition() {
+        udpStreamMonitor.setElapsedTimeRolloverCondition(UdpStreamMonitor.ELAPSED_TIME_MIN);
+        verify(udpStreamProcessor).setElapsedTimeRolloverCondition(UdpStreamMonitor.ELAPSED_TIME_MIN);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testSetElapsedTimeRolloverConditionNullArg() {
+        udpStreamMonitor.setElapsedTimeRolloverCondition(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetElapsedTimeRolloverConditionBelowRangeArg() {
+        udpStreamMonitor.setElapsedTimeRolloverCondition(UdpStreamMonitor.ELAPSED_TIME_MIN - 10);
+    }
+
+    @Test
+    public void testSetByteCountRolloverCondition() {
+        udpStreamMonitor.setByteCountRolloverCondition(UdpStreamMonitor.BYTE_COUNT_MIN);
+        verify(udpStreamProcessor).setByteCountRolloverCondition(UdpStreamMonitor.BYTE_COUNT_MIN);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testSetByteCountRolloverConditionNullArg() {
+        udpStreamMonitor.setByteCountRolloverCondition(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetByteCountRolloverConditionBelowRangeArg() {
+        udpStreamMonitor.setByteCountRolloverCondition(UdpStreamMonitor.BYTE_COUNT_MIN - 10);
+    }
+
+    @Test
+    public void testMonitoredPort() {
+        udpStreamMonitor.setMonitoredPort(UdpStreamMonitor.MONITORED_PORT_MIN);
+        assertThat(udpStreamMonitor.getMonitoredPort(), is(UdpStreamMonitor.MONITORED_PORT_MIN));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testMonitoredPortNullArg() {
+        udpStreamMonitor.setMonitoredPort(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMonitoredPortBelowRangeArg() {
+        udpStreamMonitor.setMonitoredPort(UdpStreamMonitor.MONITORED_PORT_MIN - 10);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMonitoredPortAboveRangeArg() {
+        udpStreamMonitor.setMonitoredPort(UdpStreamMonitor.MONITORED_PORT_MAX + 10);
+    }
+
+    @Test
+    public void testMonitoredAddress() {
+        String addr = "127.0.0.1";
+        udpStreamMonitor.setMonitoredAddress(addr);
+        assertThat(udpStreamMonitor.getMonitoredAddress(), is(addr));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testMonitoredAddressNullArg() {
+        udpStreamMonitor.setMonitoredAddress(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMonitoredAddressUnresolvableArg() {
+        udpStreamMonitor.setMonitoredAddress("127.0.0.0.1");
+    }
+
+    @Test
+    public void testSetCatalogFramework() {
+        CatalogFramework catalogFramework = mock(CatalogFramework.class);
+        udpStreamMonitor.setCatalogFramework(catalogFramework);
+        verify(udpStreamProcessor).setCatalogFramework(catalogFramework);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testSetCatalogFrameworkNullArg() {
+        udpStreamMonitor.setCatalogFramework(null);
+    }
+
+    @Test
+    public void testSetMetacardTypeList() {
+        List<MetacardType> metacardTypeList = Collections.emptyList();
+        udpStreamMonitor.setMetacardTypeList(metacardTypeList);
+        verify(udpStreamProcessor).setMetacardTypeList(metacardTypeList);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testSetMetacardTypeListNullArg() {
+        udpStreamMonitor.setMetacardTypeList(null);
+    }
+
+    @Test
+    public void testSetTitle() {
+        String title = "title";
+        udpStreamMonitor.setParentTitle(title);
+        assertThat(udpStreamMonitor.getTitle()
+                .get(), is(title));
+    }
+
+    @Test
+    public void testGetStreamUri() {
+        String addr = "127.0.0.1";
+        int port = 1000;
+        udpStreamMonitor.setMonitoredAddress(addr);
+        udpStreamMonitor.setMonitoredPort(port);
+        assertThat(udpStreamMonitor.getStreamUri()
+                .get()
+                .toString(), is("udp://" + addr + ":" + port));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testSetRolloverConditionNullArg() {
+        udpStreamMonitor.setRolloverCondition(null);
+    }
+
+    @Test
+    public void testSetRolloverCondition() {
+        RolloverCondition rolloverCondition = mock(RolloverCondition.class);
+        udpStreamMonitor.setRolloverCondition(rolloverCondition);
+        verify(udpStreamProcessor).setRolloverCondition(rolloverCondition);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testSetFilenameTemplateNullArg() {
+        udpStreamMonitor.setFilenameTemplate(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetFilenameTemplateBlankArg() {
+        udpStreamMonitor.setFilenameTemplate("");
+    }
+
+    @Test
+    public void testSetFilenameTemplate() {
+        String filenameTemplate = "template";
+        udpStreamMonitor.setFilenameTemplate(filenameTemplate);
+        verify(udpStreamProcessor).setFilenameTemplate(filenameTemplate);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testSetFilenameGeneratorNullArg() {
+        udpStreamMonitor.setFilenameGenerator(null);
+    }
+
+    @Test
+    public void testSetFilenameGenerator() {
+        FilenameGenerator filenameGenerator = mock(FilenameGenerator.class);
+        udpStreamMonitor.setFilenameGenerator(filenameGenerator);
+        verify(udpStreamProcessor).setFilenameGenerator(filenameGenerator);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testSetStanag4609ProcessorNullArg() {
+        udpStreamMonitor.setStanag4609Processor(null);
+    }
+
+    @Test
+    public void testSetStanag4609Processor() {
+        Stanag4609Processor stanag4609Processor = mock(Stanag4609Processor.class);
+        udpStreamMonitor.setStanag4609Processor(stanag4609Processor);
+        verify(udpStreamProcessor).setStanag4609Processor(stanag4609Processor);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testSetDefaultKlvHandlerNullArg() {
+        udpStreamMonitor.setDefaultKlvHandler(null);
+    }
+
+    @Test
+    public void testSetDefaultKlvHandler() {
+        KlvHandler klvHandler = mock(KlvHandler.class);
+        udpStreamMonitor.setDefaultKlvHandler(klvHandler);
+        verify(udpStreamProcessor).setDefaultKlvHandler(klvHandler);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testSetKlvLocationSubsampleCountNullArg() {
+        udpStreamMonitor.setKlvLocationSubsampleCount(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetKlvLocationSubsampleCountBelowRangelArg() {
+        udpStreamMonitor.setKlvLocationSubsampleCount(UdpStreamMonitor.SUBSAMPLE_COUNT_MIN - 10);
+    }
+
+    @Test
+    public void testSetKlvLocationSubsampleCount() {
+        udpStreamMonitor.setKlvLocationSubsampleCount(UdpStreamMonitor.SUBSAMPLE_COUNT_MIN);
+        verify(udpStreamProcessor).setKlvLocationSubsampleCount(UdpStreamMonitor.SUBSAMPLE_COUNT_MIN);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testSetKlvProcessorNullArg() {
+        udpStreamMonitor.setKlvProcessor(null);
+    }
+
+    @Test
+    public void testSetKlvProcessor() {
+        KlvProcessor klvProcessor = mock(KlvProcessor.class);
+        udpStreamMonitor.setKlvProcessor(klvProcessor);
+        verify(udpStreamProcessor).setKlvProcessor(klvProcessor);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testSetKlvHandlerFactoryNullArg() {
+        udpStreamMonitor.setKlvHandlerFactory(null);
+    }
+
+    @Test
+    public void testSetKlvHandlerFactory() {
+        KlvHandlerFactory klvHandlerFactory = mock(KlvHandlerFactory.class);
+        udpStreamMonitor.setKlvHandlerFactory(klvHandlerFactory);
+        verify(udpStreamProcessor).setKlvHandlerFactory(klvHandlerFactory);
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/filename/TestDateTemplateFilenameGenerator.java
+++ b/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/filename/TestDateTemplateFilenameGenerator.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.filename;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.function.Supplier;
+
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestDateTemplateFilenameGenerator {
+
+    private Date date;
+
+    private DateTemplateFilenameGenerator templateFilenameGenerator;
+
+    @Before
+    public void setup() {
+        date = new Date();
+        Supplier<Date> dateSupplier = mock(Supplier.class);
+        when(dateSupplier.get()).thenReturn(date);
+        templateFilenameGenerator = new DateTemplateFilenameGenerator();
+        templateFilenameGenerator.setDateSupplier(dateSupplier);
+    }
+
+    @Test
+    public void test() {
+
+        String fmt = "yyyy-MM-dd_hh:mm:ss";
+
+        String filename = templateFilenameGenerator.generateFilename(
+                "mpegts-stream-%{date=" + fmt + "}.ts");
+
+        SimpleDateFormat sdf = new SimpleDateFormat(fmt);
+
+        String expected = "mpegts-stream-" + sdf.format(date) + ".ts";
+
+        assertThat(filename, is(expected));
+    }
+
+    @Test
+    public void testToString() {
+        assertThat(templateFilenameGenerator.toString(), notNullValue());
+    }
+
+    @Test
+    public void testMultiplePatterns() {
+
+        String fmt1 = "yyyy-MM-dd";
+        String fmt2 = "hh:mm:ss";
+
+        String filename = templateFilenameGenerator.generateFilename(
+                "mpegts-stream-%{date=" + fmt1 + "}-xyz-%{date=" + fmt2 + "}.ts");
+
+        SimpleDateFormat sdf1 = new SimpleDateFormat(fmt1);
+        SimpleDateFormat sdf2 = new SimpleDateFormat(fmt2);
+
+        String expected =
+                "mpegts-stream-" + sdf1.format(date) + "-xyz-" + sdf2.format(date) + ".ts";
+
+        assertThat(filename, is(expected));
+
+    }
+
+    public static class TestFileExtensionFilenameGenerator {
+
+        private static final String EXT = "xyz";
+
+        private FileExtensionFilenameGenerator fileExtensionFilenameGenerator;
+
+        @Before
+        public void setup() {
+            fileExtensionFilenameGenerator = new FileExtensionFilenameGenerator(EXT);
+        }
+
+        @Test
+        public void testGenerateFilenameAddingExt() {
+            assertThat(fileExtensionFilenameGenerator.generateFilename("a"),
+                    Matchers.is("a." + EXT));
+        }
+
+        @Test
+        public void testGenerateFilenameExtAlreadyPresent() {
+            assertThat(fileExtensionFilenameGenerator.generateFilename("a." + EXT),
+                    Matchers.is("a." + EXT));
+        }
+
+        @Test
+        public void testGenerateFilenameMissingDot() {
+            assertThat(fileExtensionFilenameGenerator.generateFilename("a" + EXT),
+                    Matchers.is("a" + EXT + "." + EXT));
+        }
+
+        @Test
+        public void testToString() {
+            assertThat(fileExtensionFilenameGenerator.toString(), Matchers.notNullValue());
+        }
+    }
+}

--- a/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/filename/TestIllegalCharactersFilenameGenerator.java
+++ b/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/filename/TestIllegalCharactersFilenameGenerator.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.filename;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class TestIllegalCharactersFilenameGenerator {
+
+    private IllegalCharactersFilenameGenerator illegalCharactersFilenameGenerator;
+
+    @Before
+    public void setup() {
+        illegalCharactersFilenameGenerator = new IllegalCharactersFilenameGenerator();
+    }
+
+    @Test
+    public void testRemoveIllegalCharacters() {
+        assertThat(illegalCharactersFilenameGenerator.generateFilename("/x/y/"), is("xy"));
+        assertThat(illegalCharactersFilenameGenerator.generateFilename(":x:y:"), is("xy"));
+        assertThat(illegalCharactersFilenameGenerator.generateFilename("/:x:y:/"), is("xy"));
+    }
+
+    @Test
+    public void testToString() {
+        assertThat(illegalCharactersFilenameGenerator.toString(), notNullValue());
+    }
+}

--- a/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/filename/TestListFilenameGenerator.java
+++ b/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/filename/TestListFilenameGenerator.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.filename;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
+public class TestListFilenameGenerator {
+
+    @Test
+    public void testGenerateFilename() {
+        String testString = "foo";
+        FilenameGenerator filenameGenerator1 = mock(FilenameGenerator.class);
+        when(filenameGenerator1.generateFilename(testString)).thenReturn(testString);
+        FilenameGenerator filenameGenerator2 = mock(FilenameGenerator.class);
+        when(filenameGenerator2.generateFilename(testString)).thenReturn(testString);
+        ListFilenameGenerator listFilenameGenerator = new ListFilenameGenerator(Arrays.asList(
+                filenameGenerator1,
+                filenameGenerator2));
+        assertThat(listFilenameGenerator.generateFilename(testString), is(testString));
+        verify(filenameGenerator1).generateFilename(testString);
+        verify(filenameGenerator2).generateFilename(testString);
+    }
+
+    @Test
+    public void testToString() {
+        ListFilenameGenerator listFilenameGenerator =
+                new ListFilenameGenerator(Collections.emptyList());
+        assertThat(listFilenameGenerator.toString(), notNullValue());
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/filename/TestTempFileGeneratorImpl.java
+++ b/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/filename/TestTempFileGeneratorImpl.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.filename;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+public class TestTempFileGeneratorImpl {
+
+    @Test
+    public void test() throws IOException {
+        assertThat(new TempFileGeneratorImpl().generate(), notNullValue());
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/metacard/TestLineStringMetacardUpdater.java
+++ b/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/metacard/TestLineStringMetacardUpdater.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.metacard;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKTReader;
+import com.vividsolutions.jts.io.WKTWriter;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+
+public class TestLineStringMetacardUpdater {
+
+    private Metacard parentMetacard;
+
+    private Metacard childMetacard;
+
+    private Attribute parentAttr;
+
+    private Attribute childAttr;
+
+    private String attrName = "foo";
+
+    private LineStringMetacardUpdater lineStringMetacardUpdater;
+
+    @Before
+    public void setup() {
+        parentMetacard = mock(Metacard.class);
+        childMetacard = mock(Metacard.class);
+
+        parentAttr = mock(Attribute.class);
+        childAttr = mock(Attribute.class);
+
+        lineStringMetacardUpdater = new LineStringMetacardUpdater(attrName);
+    }
+
+    @Test
+    public void testParentMergedWithChild() throws ParseException {
+
+        when(parentAttr.getValue()).thenReturn("LINESTRING(0 0, 1 1)");
+        when(childAttr.getValue()).thenReturn("LINESTRING(2 2, 3 3)");
+
+        when(parentMetacard.getAttribute(attrName)).thenReturn(parentAttr);
+        when(childMetacard.getAttribute(attrName)).thenReturn(childAttr);
+
+        lineStringMetacardUpdater.update(parentMetacard, childMetacard);
+
+        ArgumentCaptor<Attribute> argumentCaptor = ArgumentCaptor.forClass(Attribute.class);
+
+        verify(parentMetacard).setAttribute(argumentCaptor.capture());
+
+        assertThat(argumentCaptor.getValue()
+                .getValue(), is(normalize("LINESTRING(0 0, 1 1, 2 2, 3 3)")));
+
+    }
+
+    @Test
+    public void testChildOnly() throws ParseException {
+
+        String childWkt = normalize("LINESTRING(0 0, 1 1)");
+
+        when(childAttr.getValue()).thenReturn(childWkt);
+
+        when(childMetacard.getAttribute(attrName)).thenReturn(childAttr);
+
+        lineStringMetacardUpdater.update(parentMetacard, childMetacard);
+
+        ArgumentCaptor<Attribute> argumentCaptor = ArgumentCaptor.forClass(Attribute.class);
+
+        verify(parentMetacard).setAttribute(argumentCaptor.capture());
+
+        assertThat(argumentCaptor.getValue()
+                .getValue(), is(childWkt));
+
+    }
+
+    private String normalize(String wkt) throws ParseException {
+        return new WKTWriter().write(new WKTReader().read(wkt)
+                .norm());
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/metacard/TestListMetacardUpdater.java
+++ b/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/metacard/TestListMetacardUpdater.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.metacard;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
+import ddf.catalog.data.Metacard;
+
+public class TestListMetacardUpdater {
+
+    @Test
+    public void testUpdate() {
+
+        MetacardUpdater updater1 = mock(MetacardUpdater.class);
+        MetacardUpdater updater2 = mock(MetacardUpdater.class);
+
+        ListMetacardUpdater listMetacardUpdater = new ListMetacardUpdater(Arrays.asList(updater1,
+                updater2));
+
+        Metacard parent = mock(Metacard.class);
+        Metacard child = mock(Metacard.class);
+
+        listMetacardUpdater.update(parent, child);
+
+        verify(updater1).update(parent, child);
+        verify(updater2).update(parent, child);
+
+    }
+
+    @Test
+    public void testToString() {
+        ListMetacardUpdater listMetacardUpdater = new ListMetacardUpdater(Collections.emptyList());
+        assertThat(listMetacardUpdater.toString(), notNullValue());
+    }
+}

--- a/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/netty/NettyUtility.java
+++ b/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/netty/NettyUtility.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.netty;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+public class NettyUtility {
+
+    public static List<Object> read(EmbeddedChannel channel) {
+        List<Object> output = new LinkedList<>();
+        Object inbound;
+        while ((inbound = channel.readInbound()) != null) {
+            output.add(inbound);
+        }
+        return output;
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/netty/TestDecodedStreamData.java
+++ b/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/netty/TestDecodedStreamData.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.netty;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+
+import org.jcodec.codecs.h264.io.model.NALUnit;
+import org.junit.Test;
+
+import com.connexta.alliance.libs.stanag4609.DecodedKLVMetadataPacket;
+
+/**
+ *
+ */
+public class TestDecodedStreamData {
+
+    @Test
+    public void testNALUnits() {
+
+        List<NALUnit> nalUnitList = mock(List.class);
+
+        DecodedStreamData decodedStreamData = new DecodedStreamData(nalUnitList, 1);
+
+        assertThat(decodedStreamData.getNalUnits()
+                .isPresent(), is(true));
+        assertThat(decodedStreamData.getNalUnits()
+                .get(), is(nalUnitList));
+        assertThat(decodedStreamData.getPacketId(), is(1));
+        assertThat(decodedStreamData.getDecodedKLVMetadataPacket()
+                .isPresent(), is(false));
+
+    }
+
+    @Test
+    public void testGetDecodedKLVMetadataPacket() {
+
+        DecodedKLVMetadataPacket decodedKLVMetadataPacket = mock(DecodedKLVMetadataPacket.class);
+
+        DecodedStreamData decodedStreamData = new DecodedStreamData(decodedKLVMetadataPacket, 1);
+
+        assertThat(decodedStreamData.getDecodedKLVMetadataPacket()
+                .isPresent(), is(true));
+        assertThat(decodedStreamData.getDecodedKLVMetadataPacket()
+                .get(), is(decodedKLVMetadataPacket));
+        assertThat(decodedStreamData.getPacketId(), is(1));
+        assertThat(decodedStreamData.getNalUnits()
+                .isPresent(), is(false));
+
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/netty/TestDecodedStreamDataHandler.java
+++ b/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/netty/TestDecodedStreamDataHandler.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.netty;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.locks.Lock;
+
+import org.jcodec.codecs.h264.io.model.NALUnit;
+import org.jcodec.codecs.h264.io.model.NALUnitType;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.connexta.alliance.libs.klv.KlvHandler;
+import com.connexta.alliance.libs.klv.Stanag4609Processor;
+import com.connexta.alliance.libs.stanag4609.DecodedKLVMetadataPacket;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+public class TestDecodedStreamDataHandler {
+
+    private PacketBuffer packetBuffer;
+
+    private Stanag4609Processor stanag4609Processor;
+
+    private KlvHandler defaultKlvHandler;
+
+    private Lock lock;
+
+    @Before
+    public void setup() {
+        packetBuffer = mock(PacketBuffer.class);
+        stanag4609Processor = mock(Stanag4609Processor.class);
+        defaultKlvHandler = mock(KlvHandler.class);
+        lock = mock(Lock.class);
+    }
+
+    @Test
+    public void testWrongArgumentType() throws Exception {
+
+        EmbeddedChannel channel = new EmbeddedChannel(new DecodedStreamDataHandler(packetBuffer,
+                stanag4609Processor,
+                Collections.emptyMap(),
+                defaultKlvHandler,
+                lock));
+
+        channel.writeInbound("not a DecodedStreamData.class");
+
+        verify(packetBuffer, never()).frameComplete(any());
+        verify(stanag4609Processor, never()).handle(any(), any(), any());
+
+    }
+
+    @Test
+    public void testDetectIDR() throws Exception {
+
+        List<NALUnit> nalUnitList = new LinkedList<>();
+        NALUnit nalUnit = new NALUnit(NALUnitType.IDR_SLICE, 0);
+        nalUnitList.add(nalUnit);
+
+        DecodedStreamData decodedStreamData = mock(DecodedStreamData.class);
+        when(decodedStreamData.getNalUnits()).thenReturn(Optional.of(nalUnitList));
+        when(decodedStreamData.getDecodedKLVMetadataPacket()).thenReturn(Optional.empty());
+
+        EmbeddedChannel channel = new EmbeddedChannel(new DecodedStreamDataHandler(packetBuffer,
+                stanag4609Processor,
+                Collections.emptyMap(),
+                defaultKlvHandler,
+                lock));
+
+        channel.writeInbound(decodedStreamData);
+
+        verify(packetBuffer).frameComplete(PacketBuffer.FrameType.IDR);
+
+    }
+
+    @Test
+    public void testDetectNonIDR() throws Exception {
+
+        EmbeddedChannel channel = new EmbeddedChannel(new DecodedStreamDataHandler(packetBuffer,
+                stanag4609Processor,
+                Collections.emptyMap(),
+                defaultKlvHandler,
+                lock));
+
+        List<NALUnit> nalUnitList = new LinkedList<>();
+        NALUnit nalUnit = new NALUnit(NALUnitType.NON_IDR_SLICE, 0);
+        nalUnitList.add(nalUnit);
+
+        DecodedStreamData decodedStreamData = mock(DecodedStreamData.class);
+        when(decodedStreamData.getNalUnits()).thenReturn(Optional.of(nalUnitList));
+        when(decodedStreamData.getDecodedKLVMetadataPacket()).thenReturn(Optional.empty());
+
+        channel.writeInbound(decodedStreamData);
+
+        verify(packetBuffer).frameComplete(PacketBuffer.FrameType.NON_IDR);
+
+    }
+
+    @Test
+    public void testKlvCalled() throws Exception {
+
+        Map<String, KlvHandler> klvHandlerMap = new HashMap<>();
+
+        EmbeddedChannel channel = new EmbeddedChannel(new DecodedStreamDataHandler(packetBuffer,
+                stanag4609Processor,
+                klvHandlerMap,
+                defaultKlvHandler,
+                lock));
+
+        DecodedKLVMetadataPacket decodedKLVMetadataPacket = mock(DecodedKLVMetadataPacket.class);
+
+        int pid = 2;
+
+        DecodedStreamData decodedStreamData = mock(DecodedStreamData.class);
+        when(decodedStreamData.getPacketId()).thenReturn(pid);
+        when(decodedStreamData.getDecodedKLVMetadataPacket()).thenReturn(Optional.of(
+                decodedKLVMetadataPacket));
+        when(decodedStreamData.getNalUnits()).thenReturn(Optional.empty());
+
+        channel.writeInbound(decodedStreamData);
+
+        verify(stanag4609Processor).handle(klvHandlerMap,
+                defaultKlvHandler,
+                Collections.singletonMap(pid, Collections.singletonList(decodedKLVMetadataPacket)));
+
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/netty/TestMTSPacketToPESPacketDecoder.java
+++ b/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/netty/TestMTSPacketToPESPacketDecoder.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.netty;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+
+import org.jcodec.containers.mps.MTSUtils;
+import org.jcodec.containers.mps.psi.PMTSection;
+import org.junit.Test;
+import org.taktik.mpegts.MTSPacket;
+import org.taktik.mpegts.PATSection;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+public class TestMTSPacketToPESPacketDecoder {
+
+    /**
+     * This test sends MTSPackets to the decoder so that the decoder outputs one video pes packet.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testDecode() throws Exception {
+
+        MTSUtils.StreamType streamType = MTSUtils.StreamType.VIDEO_H264;
+
+        byte expectedByte1 = 0x01;
+        byte expectedByte2 = 0x02;
+        byte expectedByte3 = 0x03;
+        byte expectedByte4 = 0x04;
+
+        int programMapTableId = 1;
+        int videoPacketId = 2;
+
+        MTSPacketToPESPacketDecoder decoder = new MTSPacketToPESPacketDecoder();
+
+        PATSection patSection = mock(PATSection.class);
+        when(patSection.getPrograms()).thenReturn(Collections.singletonMap(1, programMapTableId));
+
+        MTSPacketToPESPacketDecoder.PATSectionParser patSectionParser = mock(
+                MTSPacketToPESPacketDecoder.PATSectionParser.class);
+        when(patSectionParser.parse(any())).thenReturn(patSection);
+        decoder.setPatSectionParser(patSectionParser);
+
+        MTSPacket programAssociationTablePacket = mock(MTSPacket.class);
+        when(programAssociationTablePacket.getPid()).thenReturn(MTSPacketToPESPacketDecoder.PROGRAM_ASSOCIATION_TABLE_PID);
+        when(programAssociationTablePacket.isPayloadUnitStartIndicator()).thenReturn(true);
+        when(programAssociationTablePacket.getPayload()).thenReturn(ByteBuffer.wrap(new byte[] {
+                0x00}));
+
+        PMTSection.PMTStream pmtStream = mock(PMTSection.PMTStream.class);
+        when(pmtStream.getStreamType()).thenReturn(streamType);
+        when(pmtStream.getPid()).thenReturn(videoPacketId);
+
+        PMTSection pmtSection = mock(PMTSection.class);
+        when(pmtSection.getStreams()).thenReturn(new PMTSection.PMTStream[] {pmtStream});
+
+        MTSPacketToPESPacketDecoder.PMTSectionParser pmtSectionParser = mock(
+                MTSPacketToPESPacketDecoder.PMTSectionParser.class);
+        when(pmtSectionParser.parse(any())).thenReturn(pmtSection);
+        decoder.setPmtSectionParser(pmtSectionParser);
+
+        MTSPacket programMapTablePacket = mock(MTSPacket.class);
+        when(programMapTablePacket.getPid()).thenReturn(programMapTableId);
+        when(programMapTablePacket.isPayloadUnitStartIndicator()).thenReturn(true);
+        when(programMapTablePacket.getPayload()).thenReturn(ByteBuffer.wrap(new byte[] {0x00}));
+
+        MTSPacket elementaryStreamPacket1 = createElementary(true, videoPacketId, expectedByte1);
+        MTSPacket elementaryStreamPacket2 = createElementary(false, videoPacketId, expectedByte2);
+        MTSPacket elementaryStreamPacket3 = createElementary(false, videoPacketId, expectedByte3);
+        MTSPacket elementaryStreamPacket4 = createElementary(false, videoPacketId, expectedByte4);
+        MTSPacket elementaryStreamPacket5 = createElementary(true, videoPacketId, (byte) 0x00);
+
+        EmbeddedChannel channel = new EmbeddedChannel(decoder);
+
+        channel.writeInbound(programAssociationTablePacket,
+                programMapTablePacket,
+                elementaryStreamPacket1,
+                elementaryStreamPacket2,
+                elementaryStreamPacket3,
+                elementaryStreamPacket4,
+                elementaryStreamPacket5);
+
+        List<Object> outputList = NettyUtility.read(channel);
+
+        assertThat(outputList, hasSize(1));
+        assertThat(outputList.get(0), is(instanceOf(PESPacket.class)));
+        PESPacket pesPacket = (PESPacket) outputList.get(0);
+        assertThat(pesPacket.getPacketId(), is(videoPacketId));
+        assertThat(pesPacket.getStreamType(), is(streamType));
+        assertThat(pesPacket.getPayload(),
+                is(new byte[] {expectedByte1, expectedByte2, expectedByte3, expectedByte4}));
+
+    }
+
+    private MTSPacket createElementary(boolean isStart, int pid, byte data) {
+        MTSPacket elementaryStreamPacket5 = mock(MTSPacket.class);
+        when(elementaryStreamPacket5.getPid()).thenReturn(pid);
+        when(elementaryStreamPacket5.isPayloadUnitStartIndicator()).thenReturn(isStart);
+        when(elementaryStreamPacket5.getPayload()).thenReturn(ByteBuffer.wrap(new byte[] {data}));
+        return elementaryStreamPacket5;
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/netty/TestPESPacketToApplicationDataDecoder.java
+++ b/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/netty/TestPESPacketToApplicationDataDecoder.java
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.netty;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import org.jcodec.codecs.h264.io.model.NALUnit;
+import org.jcodec.containers.mps.MTSUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.connexta.alliance.libs.stanag4609.DecodedKLVMetadataPacket;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+public class TestPESPacketToApplicationDataDecoder {
+
+    private static final byte[] EMPTY_ARRAY = new byte[] {};
+
+    private static final ByteBuffer EMPTY_BUF = ByteBuffer.wrap(EMPTY_ARRAY);
+
+    private PESPacketToApplicationDataDecoder decoder;
+
+    private PESPacket pesPacket;
+
+    @Before
+    public void setup() {
+        decoder = new PESPacketToApplicationDataDecoder(true);
+        pesPacket = mock(PESPacket.class);
+    }
+
+    @Test
+    public void testDecodeNALUnits() throws Exception {
+
+        when(pesPacket.getStreamType()).thenReturn(MTSUtils.StreamType.VIDEO_H264);
+        when(pesPacket.getPayload()).thenReturn(EMPTY_ARRAY);
+
+        PESPacketToApplicationDataDecoder.NALReader nalReader = mock(
+                PESPacketToApplicationDataDecoder.NALReader.class);
+        when(nalReader.next(any())).thenReturn(EMPTY_BUF)
+                .thenReturn(EMPTY_BUF)
+                .thenReturn(null);
+        decoder.setNalReader(nalReader);
+
+        PESPacketToApplicationDataDecoder.NALParser nalParser = mock(
+                PESPacketToApplicationDataDecoder.NALParser.class);
+
+        NALUnit nalUnit1 = mock(NALUnit.class);
+        NALUnit nalUnit2 = mock(NALUnit.class);
+
+        when(nalParser.parse(any())).thenReturn(nalUnit1)
+                .thenReturn(nalUnit2);
+
+        decoder.setNalParser(nalParser);
+
+        EmbeddedChannel channel = new EmbeddedChannel(decoder);
+
+        channel.writeInbound(pesPacket);
+
+        List<Object> outputList = NettyUtility.read(channel);
+
+        assertThat(outputList, hasSize(1));
+        assertThat(outputList.get(0), is(instanceOf(DecodedStreamData.class)));
+        DecodedStreamData decodedStreamData = (DecodedStreamData) outputList.get(0);
+        assertThat(decodedStreamData.getDecodedKLVMetadataPacket()
+                .isPresent(), is(false));
+        assertThat(decodedStreamData.getNalUnits()
+                .isPresent(), is(true));
+        assertThat(decodedStreamData.getNalUnits()
+                .get(), hasSize(2));
+        assertThat(decodedStreamData.getNalUnits()
+                .get()
+                .get(0), is(nalUnit1));
+        assertThat(decodedStreamData.getNalUnits()
+                .get()
+                .get(1), is(nalUnit2));
+    }
+
+    @Test
+    public void testKlvMetadataPrivateData() throws Exception {
+
+        when(pesPacket.getStreamType()).thenReturn(MTSUtils.StreamType.PRIVATE_DATA);
+        when(pesPacket.getPacketId()).thenReturn(1);
+        when(pesPacket.getPayload()).thenReturn(EMPTY_ARRAY);
+
+        PESPacketToApplicationDataDecoder.KlvParser klvParser = mock(
+                PESPacketToApplicationDataDecoder.KlvParser.class);
+        DecodedKLVMetadataPacket decodedKLVMetadataPacket = mock(DecodedKLVMetadataPacket.class);
+        when(klvParser.parse(eq(EMPTY_ARRAY), any())).thenReturn(decodedKLVMetadataPacket);
+
+        decoder.setKlvParser(klvParser);
+
+        EmbeddedChannel channel = new EmbeddedChannel(decoder);
+
+        channel.writeInbound(pesPacket);
+
+        List<Object> outputList = NettyUtility.read(channel);
+
+        assertThat(outputList, hasSize(1));
+        assertThat(outputList.get(0), is(instanceOf(DecodedStreamData.class)));
+        DecodedStreamData decodedStreamData = (DecodedStreamData) outputList.get(0);
+        assertThat(decodedStreamData.getDecodedKLVMetadataPacket()
+                .isPresent(), is(true));
+        assertThat(decodedStreamData.getNalUnits()
+                .isPresent(), is(false));
+        assertThat(decodedStreamData.getPacketId(), is(1));
+        assertThat(decodedStreamData.getDecodedKLVMetadataPacket()
+                .get(), is(decodedKLVMetadataPacket));
+
+    }
+
+    @Test
+    public void testKlvMetadataMetaPes() throws Exception {
+
+        when(pesPacket.getStreamType()).thenReturn(MTSUtils.StreamType.META_PES);
+        when(pesPacket.getPacketId()).thenReturn(1);
+        when(pesPacket.getPayload()).thenReturn(EMPTY_ARRAY);
+
+        PESPacketToApplicationDataDecoder.KlvParser klvParser = mock(
+                PESPacketToApplicationDataDecoder.KlvParser.class);
+        DecodedKLVMetadataPacket decodedKLVMetadataPacket = mock(DecodedKLVMetadataPacket.class);
+        when(klvParser.parse(eq(EMPTY_ARRAY), any())).thenReturn(decodedKLVMetadataPacket);
+
+        decoder.setKlvParser(klvParser);
+
+        EmbeddedChannel channel = new EmbeddedChannel(decoder);
+
+        channel.writeInbound(pesPacket);
+
+        List<Object> outputList = NettyUtility.read(channel);
+
+        assertThat(outputList, hasSize(1));
+        assertThat(outputList.get(0), is(instanceOf(DecodedStreamData.class)));
+        DecodedStreamData decodedStreamData = (DecodedStreamData) outputList.get(0);
+        assertThat(decodedStreamData.getDecodedKLVMetadataPacket()
+                .isPresent(), is(true));
+        assertThat(decodedStreamData.getNalUnits()
+                .isPresent(), is(false));
+        assertThat(decodedStreamData.getPacketId(), is(1));
+        assertThat(decodedStreamData.getDecodedKLVMetadataPacket()
+                .get(), is(decodedKLVMetadataPacket));
+
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/netty/TestPacketBuffer.java
+++ b/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/netty/TestPacketBuffer.java
@@ -1,0 +1,215 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.netty;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.connexta.alliance.video.stream.mpegts.filename.TempFileGenerator;
+import com.connexta.alliance.video.stream.mpegts.rollover.RolloverCondition;
+
+public class TestPacketBuffer {
+
+    private PacketBuffer packetBuffer;
+
+    private RolloverCondition rolloverCondition;
+
+    private Optional<File> tempFile;
+
+    private OutputStream outputStream;
+
+    private ByteArrayOutputStream os;
+
+    @Before
+    public void setup() throws IOException {
+        TempFileGenerator tempFileGenerator = mock(TempFileGenerator.class);
+        when(tempFileGenerator.generate()).thenReturn(new File("x"));
+        packetBuffer = new PacketBuffer();
+        outputStream = mock(OutputStream.class);
+        packetBuffer.setOutputStreamFactory((file, append) -> outputStream);
+        packetBuffer.setTempFileGenerator(tempFileGenerator);
+        rolloverCondition = mock(RolloverCondition.class);
+        when(rolloverCondition.isRolloverReady(any())).thenReturn(true);
+        tempFile = null;
+        os = new ByteArrayOutputStream();
+    }
+
+    @Test
+    public void testToString() {
+        assertThat(packetBuffer.toString(), notNullValue());
+    }
+
+    @Test
+    public void testGetAgeInitial() {
+        assertThat(packetBuffer.getAge(), is(0L));
+    }
+
+    @Test
+    public void testRotateWithNoData() {
+        tempFile = packetBuffer.rotate(rolloverCondition);
+        assertThat(tempFile.isPresent(), is(false));
+    }
+
+    @Test
+    public void testRotateWithDataNoFrames() {
+        packetBuffer.write(new byte[] {0x01});
+        tempFile = packetBuffer.rotate(rolloverCondition);
+        assertThat(tempFile.isPresent(), is(false));
+    }
+
+    /**
+     * The data being written to the packet buffer exceeds the max incomplete frame byte count.
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testWriteWithOnlyUnknownFrames() throws IOException {
+        byte[] payload = new byte[] {0x01, 0x02};
+        packetBuffer.setMaxIncompleteFrameBytes(1);
+        packetBuffer.write(payload);
+        verify(outputStream).write(payload);
+    }
+
+    /**
+     * A full frameset has been written, verify that only the compelete frameset has been flushed
+     */
+    @Test
+    public void testWriteWithVideoData1() {
+
+        packetBuffer.setOutputStreamFactory((file, append) -> os);
+
+        completeVideoSequence(new byte[] {0x01, 0x02, 0x03, 0x01, 0x02, 0x03, 0x01, 0x02, 0x03,
+                0x01, 0x02, 0x03});
+
+        assertThat(os.toByteArray(),
+                is(new byte[] {0x01, 0x02, 0x03, 0x01, 0x02, 0x03, 0x01, 0x02, 0x03}));
+
+    }
+
+    private void writePacket(byte b) {
+        packetBuffer.write(new byte[] {b});
+    }
+
+    private void idr() {
+        packetBuffer.frameComplete(PacketBuffer.FrameType.IDR);
+    }
+
+    private void nonidr() {
+        packetBuffer.frameComplete(PacketBuffer.FrameType.NON_IDR);
+    }
+
+    /**
+     * We don't know if the frameset is complete, so no data should be flushed
+     */
+    @Test
+    public void testWriteWithVideoData2() {
+
+        packetBuffer.setOutputStreamFactory((file, append) -> os);
+
+        writePacket((byte) 0x01);
+        writePacket((byte) 0x02);
+        writePacket((byte) 0x03);
+        idr();
+
+        writePacket((byte) 0x01);
+        writePacket((byte) 0x02);
+        writePacket((byte) 0x03);
+        nonidr();
+
+        writePacket((byte) 0x01);
+        writePacket((byte) 0x02);
+        writePacket((byte) 0x03);
+        nonidr();
+
+        assertThat(os.toByteArray(), is(new byte[] {}));
+
+    }
+
+    /**
+     * Test that the packet buffer does not rotate when the rollover condition is false.
+     */
+    @Test
+    public void testRotate1() {
+
+        completeVideoSequence(new byte[] {0x01, 0x02, 0x03, 0x01, 0x02, 0x03, 0x01, 0x02, 0x03,
+                0x01, 0x02, 0x03});
+
+        RolloverCondition rc = mock(RolloverCondition.class);
+        when(rc.isRolloverReady(any())).thenReturn(false);
+
+        Optional<File> file = packetBuffer.rotate(rc);
+        assertThat(file, is(Optional.empty()));
+
+    }
+
+    /**
+     * Test that the packet buffer does rotate when the condition is true.
+     */
+    @Test
+    public void testRotate2() {
+
+        completeVideoSequence(new byte[] {0x01, 0x02, 0x03, 0x01, 0x02, 0x03, 0x01, 0x02, 0x03,
+                0x01, 0x02, 0x03});
+
+        RolloverCondition rc = mock(RolloverCondition.class);
+        when(rc.isRolloverReady(any())).thenReturn(true);
+
+        Optional<File> file = packetBuffer.rotate(rc);
+        assertThat(file.isPresent(), is(true));
+
+    }
+
+    /**
+     * Always call with an array of 12 elements!
+     */
+    private void completeVideoSequence(byte[] data) {
+
+        assertThat(data.length, is(12));
+
+        writePacket(data[0]);
+        writePacket(data[1]);
+        writePacket(data[2]);
+        idr();
+
+        writePacket(data[3]);
+        writePacket(data[4]);
+        writePacket(data[5]);
+        nonidr();
+
+        writePacket(data[6]);
+        writePacket(data[7]);
+        writePacket(data[8]);
+        nonidr();
+
+        writePacket(data[9]);
+        writePacket(data[10]);
+        writePacket(data[11]);
+        idr();
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/netty/TestRawUdpDataToMTSPacketDecoder.java
+++ b/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/netty/TestRawUdpDataToMTSPacketDecoder.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.netty;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.Test;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.channel.socket.DatagramPacket;
+
+public class TestRawUdpDataToMTSPacketDecoder {
+
+    @Test
+    public void test() throws Exception {
+
+        int packetCount = 100;
+
+        List<DatagramPacket> datagramPackets = toDatagrams(flatten(createTsPackets(packetCount)));
+
+        PacketBuffer packetBuffer = mock(PacketBuffer.class);
+
+        EmbeddedChannel channel =
+                new EmbeddedChannel(new RawUdpDataToMTSPacketDecoder(packetBuffer));
+
+        datagramPackets.forEach(channel::writeInbound);
+
+        List<Object> outputList = NettyUtility.read(channel);
+
+        assertThat(outputList, hasSize(packetCount));
+
+    }
+
+    /**
+     * Create a list of fake MPEG-TS packets.
+     *
+     * @param packetCount number of packet
+     * @return list of raw packets
+     */
+    private List<byte[]> createTsPackets(int packetCount) {
+
+        List<byte[]> packets = new LinkedList<>();
+
+        for (int i = 0; i < packetCount; i++) {
+            byte[] bytes = new byte[RawUdpDataToMTSPacketDecoder.TS_PACKET_SIZE];
+            bytes[0] = RawUdpDataToMTSPacketDecoder.TS_SYNC;
+            packets.add(bytes);
+        }
+
+        return packets;
+    }
+
+    /**
+     * Flatten a list of byte arrays into a single byte array.
+     *
+     * @param packets list of raw packets
+     * @return raw packet data
+     */
+    private byte[] flatten(List<byte[]> packets) {
+
+        byte[] bytes = new byte[0];
+
+        for (byte[] in : packets) {
+            bytes = ArrayUtils.addAll(bytes, in);
+        }
+
+        return bytes;
+    }
+
+    /**
+     * Split an array of bytes into datagram packets.
+     *
+     * @param bytes payload data
+     * @return list of datagrams
+     */
+    private List<DatagramPacket> toDatagrams(byte[] bytes) {
+
+        int datagramSize = 1500;
+
+        List<DatagramPacket> datagrams = new LinkedList<>();
+
+        byte[] tmp = bytes;
+
+        while (tmp.length > datagramSize) {
+            byte[] subarray = ArrayUtils.subarray(tmp, 0, datagramSize);
+            datagrams.add(new DatagramPacket(Unpooled.wrappedBuffer(subarray), null));
+            tmp = ArrayUtils.subarray(tmp, datagramSize, tmp.length);
+        }
+
+        if (tmp.length > 0) {
+            datagrams.add(new DatagramPacket(Unpooled.wrappedBuffer(tmp), null));
+        }
+
+        return datagrams;
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/netty/TestUdpStreamProcessor.java
+++ b/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/netty/TestUdpStreamProcessor.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.netty;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.connexta.alliance.libs.klv.KlvHandler;
+import com.connexta.alliance.libs.klv.KlvHandlerFactory;
+import com.connexta.alliance.libs.klv.KlvProcessor;
+import com.connexta.alliance.libs.klv.Stanag4609Processor;
+import com.connexta.alliance.video.stream.mpegts.StreamMonitor;
+import com.connexta.alliance.video.stream.mpegts.filename.FilenameGenerator;
+import com.connexta.alliance.video.stream.mpegts.rollover.RolloverCondition;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.data.MetacardType;
+
+public class TestUdpStreamProcessor {
+
+    @Test
+    public void testCreateChannelHandlers() {
+        StreamMonitor streamMonitor = mock(StreamMonitor.class);
+        Stanag4609Processor stanag4609Processor = mock(Stanag4609Processor.class);
+        KlvHandler defaultKlvHandler = mock(KlvHandler.class);
+        RolloverCondition rolloverCondition = mock(RolloverCondition.class);
+        String filenameTemplate = "template";
+        FilenameGenerator filenameGenerator = mock(FilenameGenerator.class);
+        KlvProcessor klvProcessor = mock(KlvProcessor.class);
+        List<MetacardType> metacardTypeList = mock(List.class);
+        CatalogFramework catalogFramework = mock(CatalogFramework.class);
+        KlvHandlerFactory klvHandlerFactory = mock(KlvHandlerFactory.class);
+        when(klvHandlerFactory.createStanag4609Handlers()).thenReturn(Collections.emptyMap());
+        UdpStreamProcessor udpStreamProcessor = new UdpStreamProcessor(streamMonitor);
+        udpStreamProcessor.setStanag4609Processor(stanag4609Processor);
+        udpStreamProcessor.setKlvHandlerFactory(klvHandlerFactory);
+        udpStreamProcessor.setDefaultKlvHandler(defaultKlvHandler);
+        udpStreamProcessor.setRolloverCondition(rolloverCondition);
+        udpStreamProcessor.setFilenameTemplate(filenameTemplate);
+        udpStreamProcessor.setFilenameGenerator(filenameGenerator);
+        udpStreamProcessor.setKlvProcessor(klvProcessor);
+        udpStreamProcessor.setMetacardTypeList(metacardTypeList);
+        udpStreamProcessor.setCatalogFramework(catalogFramework);
+
+        udpStreamProcessor.init();
+        try {
+            assertThat(udpStreamProcessor.createChannelHandlers(), notNullValue());
+        } finally {
+            udpStreamProcessor.shutdown();
+        }
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/rollover/TestBooleanOrRolloverCondition.java
+++ b/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/rollover/TestBooleanOrRolloverCondition.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.rollover;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.connexta.alliance.video.stream.mpegts.netty.PacketBuffer;
+
+public class TestBooleanOrRolloverCondition {
+
+    private BooleanOrRolloverCondition firstCondition;
+
+    private BooleanOrRolloverCondition secondCondition;
+
+    private BooleanOrRolloverCondition condition;
+
+    @Before
+    public void setup() {
+        firstCondition = mock(BooleanOrRolloverCondition.class);
+        secondCondition = mock(BooleanOrRolloverCondition.class);
+        condition = new BooleanOrRolloverCondition(firstCondition, secondCondition);
+    }
+
+    private void assertThatBooleanOr(boolean x, boolean y, boolean expected) {
+
+        when(firstCondition.isRolloverReady(any())).thenReturn(x);
+        when(secondCondition.isRolloverReady(any())).thenReturn(y);
+
+        assertThat(condition.isRolloverReady(mock(PacketBuffer.class)), is(expected));
+    }
+
+    @Test
+    public void testBasicLogic() {
+        assertThatBooleanOr(false, false, false);
+        assertThatBooleanOr(false, true, true);
+        assertThatBooleanOr(true, false, true);
+        assertThatBooleanOr(true, true, true);
+    }
+
+    @Test
+    public void testToString() {
+        assertThat(condition.toString(), not(nullValue()));
+    }
+
+    @Test
+    public void testAccept() {
+
+        RolloverCondition.Visitor visitor = mock(RolloverCondition.Visitor.class);
+
+        condition.accept(visitor);
+
+        verify(firstCondition).accept(visitor);
+        verify(secondCondition).accept(visitor);
+
+        verify(visitor).visit(condition);
+
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/rollover/TestByteCountRolloverCondition.java
+++ b/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/rollover/TestByteCountRolloverCondition.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.rollover;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.connexta.alliance.video.stream.mpegts.netty.PacketBuffer;
+
+public class TestByteCountRolloverCondition {
+
+    private static final long THRESHOLD = 100;
+
+    private ByteCountRolloverCondition condition;
+
+    private PacketBuffer packetBuffer;
+
+    @Before
+    public void setup() {
+        condition = new ByteCountRolloverCondition(THRESHOLD);
+        packetBuffer = mock(PacketBuffer.class);
+    }
+
+    @Test
+    public void testCurrentLessThanThreshold() {
+
+        when(packetBuffer.getByteCount()).thenReturn(THRESHOLD - 1);
+
+        assertThat(condition.isRolloverReady(packetBuffer), is(false));
+
+    }
+
+    @Test
+    public void testCurrentEqualToThreshold() {
+
+        when(packetBuffer.getByteCount()).thenReturn(THRESHOLD);
+
+        assertThat(condition.isRolloverReady(packetBuffer), is(true));
+
+    }
+
+    @Test
+    public void testCurrentGreaterThanThreshold() {
+
+        when(packetBuffer.getByteCount()).thenReturn(THRESHOLD + 1);
+
+        assertThat(condition.isRolloverReady(packetBuffer), is(true));
+
+    }
+
+    @Test
+    public void testSetter() {
+        condition.setByteCountThreshold(THRESHOLD - 1);
+        assertThat(condition.getByteCountThreshold(), is(THRESHOLD - 1));
+    }
+
+    @Test
+    public void testAccept() {
+        RolloverCondition.Visitor visitor = mock(RolloverCondition.Visitor.class);
+        condition.accept(visitor);
+        verify(visitor).visit(condition);
+    }
+
+    @Test
+    public void testToString() {
+        assertThat(condition.toString(), notNullValue());
+    }
+}

--- a/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/rollover/TestCatalogRolloverAction.java
+++ b/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/rollover/TestCatalogRolloverAction.java
@@ -1,0 +1,304 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.rollover;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.codice.ddf.security.common.Security;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.connexta.alliance.libs.klv.AttributeNameConstants;
+import com.connexta.alliance.video.stream.mpegts.filename.FilenameGenerator;
+import com.connexta.alliance.video.stream.mpegts.netty.StreamProcessor;
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKTReader;
+import com.vividsolutions.jts.io.WKTWriter;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.content.operation.CreateStorageRequest;
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.operation.CreateRequest;
+import ddf.catalog.operation.CreateResponse;
+import ddf.catalog.operation.Update;
+import ddf.catalog.operation.UpdateRequest;
+import ddf.catalog.operation.UpdateResponse;
+import ddf.catalog.source.IngestException;
+import ddf.catalog.source.SourceUnavailableException;
+
+public class TestCatalogRolloverAction {
+
+    private CatalogFramework catalogFramework;
+
+    private File tempFile;
+
+    private CatalogRolloverAction catalogRolloverAction;
+
+    private Metacard createdParentMetacard;
+
+    private Metacard createdChildMetacard;
+
+    private UpdateResponse childUpdateResponse;
+
+    private UpdateResponse parentUpdateResponse;
+
+    private URI uri;
+
+    private String title;
+
+    private String childWkt;
+
+    @Before
+    public void setup() throws SourceUnavailableException, IngestException {
+        FilenameGenerator filenameGenerator = mock(FilenameGenerator.class);
+        String filenameTemplate = "filenameTemplate";
+        StreamProcessor streamProcessor = mock(StreamProcessor.class);
+        catalogFramework = mock(CatalogFramework.class);
+        Security security = mock(Security.class);
+        MetacardType metacardType = mock(MetacardType.class);
+        tempFile = new File("someTempFile");
+
+        uri = URI.create("udp://127.0.0.1:10000");
+        title = "theTitleString";
+        childWkt = "POLYGON (( 0.5 0.5, 1.5 0.5, 1.5 1.5, 0.5 1.5, 0.5 0.5 ))";
+
+        catalogRolloverAction = new CatalogRolloverAction(filenameGenerator,
+                filenameTemplate,
+                streamProcessor,
+                catalogFramework,
+                security,
+                Collections.singletonList(metacardType));
+
+        createdParentMetacard = mock(Metacard.class);
+        createdChildMetacard = mock(Metacard.class);
+        Metacard updatedParentMetacard = mock(Metacard.class);
+        Metacard updatedChildMetacard = mock(Metacard.class);
+        CreateResponse createResponse = mock(CreateResponse.class);
+        CreateResponse storageCreateResponse = mock(CreateResponse.class);
+        Update childUpdate = mock(Update.class);
+        childUpdateResponse = mock(UpdateResponse.class);
+        Update parentUpdate = mock(Update.class);
+        parentUpdateResponse = mock(UpdateResponse.class);
+
+        when(createResponse.getCreatedMetacards()).thenReturn(Collections.singletonList(
+                createdParentMetacard));
+        when(storageCreateResponse.getCreatedMetacards()).thenReturn(Collections.singletonList(
+                createdChildMetacard));
+        when(childUpdate.getNewMetacard()).thenReturn(updatedChildMetacard);
+        when(childUpdateResponse.getUpdatedMetacards()).thenReturn(Collections.singletonList(
+                childUpdate));
+        when(parentUpdate.getNewMetacard()).thenReturn(updatedParentMetacard);
+        when(parentUpdateResponse.getUpdatedMetacards()).thenReturn(Collections.singletonList(
+                parentUpdate));
+        when(filenameGenerator.generateFilename(any())).thenReturn("someFileName");
+        when(streamProcessor.getStreamUri()).thenReturn(Optional.of(uri));
+        when(streamProcessor.getTitle()).thenReturn(Optional.of(title));
+        when(catalogFramework.create(any(CreateRequest.class))).thenReturn(createResponse);
+        when(catalogFramework.create(any(CreateStorageRequest.class))).thenReturn(
+                storageCreateResponse);
+        when(catalogFramework.update(any(UpdateRequest.class))).thenReturn(childUpdateResponse)
+                .thenReturn(parentUpdateResponse);
+        when(createdChildMetacard.getLocation()).thenReturn(childWkt);
+    }
+
+    @Test
+    public void testThatParentMetacardHasResourceURI()
+            throws RolloverActionException, SourceUnavailableException, IngestException {
+
+        catalogRolloverAction.doAction(tempFile);
+
+        ArgumentCaptor<CreateRequest> argumentCaptor = ArgumentCaptor.forClass(CreateRequest.class);
+
+        verify(catalogFramework).create(argumentCaptor.capture());
+
+        assertThat(argumentCaptor.getValue()
+                .getMetacards()
+                .get(0)
+                .getResourceURI(), is(uri));
+
+    }
+
+    @Test
+    public void testThatParentMetacardHasTitle()
+            throws RolloverActionException, SourceUnavailableException, IngestException {
+
+        catalogRolloverAction.doAction(tempFile);
+
+        ArgumentCaptor<CreateRequest> argumentCaptor = ArgumentCaptor.forClass(CreateRequest.class);
+
+        verify(catalogFramework).create(argumentCaptor.capture());
+
+        assertThat(argumentCaptor.getValue()
+                .getMetacards()
+                .get(0)
+                .getTitle(), is(title));
+
+    }
+
+    /**
+     * Test that the parent update succeeded after an initial failure. Confirm that the parent has
+     * the proper location, which was a part of the update.
+     *
+     * @throws RolloverActionException
+     * @throws SourceUnavailableException
+     * @throws IngestException
+     */
+    @Test
+    public void testRetry()
+            throws RolloverActionException, SourceUnavailableException, IngestException {
+
+        when(catalogFramework.update(any(UpdateRequest.class))).thenThrow(RolloverActionException.class)
+                .thenReturn(childUpdateResponse)
+                .thenReturn(parentUpdateResponse);
+
+        catalogRolloverAction.doAction(tempFile);
+
+        ArgumentCaptor<UpdateRequest> argumentCaptor = ArgumentCaptor.forClass(UpdateRequest.class);
+
+        verify(catalogFramework, times(3)).update(argumentCaptor.capture());
+
+        ArgumentCaptor<Attribute> attributeCaptor = ArgumentCaptor.forClass(Attribute.class);
+        verify(createdParentMetacard, atLeastOnce()).setAttribute(attributeCaptor.capture());
+
+        List<Attribute> geoAttributeList = attributeCaptor.getAllValues()
+                .stream()
+                .filter(attr -> attr.getName()
+                        .equals(Metacard.GEOGRAPHY))
+                .collect(Collectors.toList());
+
+        assertThat(geoAttributeList, hasSize(1));
+        assertThat(geoAttributeList.get(0)
+                .getValue(), is(childWkt));
+
+    }
+
+    @Test
+    public void testTemporalStart()
+            throws RolloverActionException, SourceUnavailableException, IngestException {
+
+        Date temporalStart = new Date();
+
+        when(createdChildMetacard.getAttribute(AttributeNameConstants.TEMPORAL_START)).thenReturn(
+                new AttributeImpl(AttributeNameConstants.TEMPORAL_START, temporalStart));
+
+        catalogRolloverAction.doAction(tempFile);
+
+        ArgumentCaptor<UpdateRequest> argumentCaptor = ArgumentCaptor.forClass(UpdateRequest.class);
+
+        verify(catalogFramework, times(2)).update(argumentCaptor.capture());
+
+        ArgumentCaptor<Attribute> attributeCaptor = ArgumentCaptor.forClass(Attribute.class);
+        verify(createdParentMetacard, atLeastOnce()).setAttribute(attributeCaptor.capture());
+
+        List<Attribute> geoAttributeList = attributeCaptor.getAllValues()
+                .stream()
+                .filter(attr -> attr.getName()
+                        .equals(AttributeNameConstants.TEMPORAL_START))
+                .collect(Collectors.toList());
+
+        assertThat(geoAttributeList, hasSize(1));
+        assertThat(geoAttributeList.get(0)
+                .getValue(), is(temporalStart));
+
+    }
+
+    @Test
+    public void testTemporalEnd()
+            throws RolloverActionException, SourceUnavailableException, IngestException {
+
+        Date temporalEnd = new Date();
+
+        when(createdChildMetacard.getAttribute(AttributeNameConstants.TEMPORAL_END)).thenReturn(new AttributeImpl(
+                AttributeNameConstants.TEMPORAL_END,
+                temporalEnd));
+
+        catalogRolloverAction.doAction(tempFile);
+
+        ArgumentCaptor<UpdateRequest> argumentCaptor = ArgumentCaptor.forClass(UpdateRequest.class);
+
+        verify(catalogFramework, times(2)).update(argumentCaptor.capture());
+
+        ArgumentCaptor<Attribute> attributeCaptor = ArgumentCaptor.forClass(Attribute.class);
+        verify(createdParentMetacard, atLeastOnce()).setAttribute(attributeCaptor.capture());
+
+        List<Attribute> geoAttributeList = attributeCaptor.getAllValues()
+                .stream()
+                .filter(attr -> attr.getName()
+                        .equals(AttributeNameConstants.TEMPORAL_END))
+                .collect(Collectors.toList());
+
+        assertThat(geoAttributeList, hasSize(1));
+        assertThat(geoAttributeList.get(0)
+                .getValue(), is(temporalEnd));
+
+    }
+
+    @Test
+    public void testLocationUnion()
+            throws RolloverActionException, SourceUnavailableException, IngestException,
+            ParseException {
+
+        String parentWkt = "POLYGON (( 0 0, 1 0, 1 1, 0 1, 0 0 ))";
+
+        when(createdParentMetacard.getLocation()).thenReturn(parentWkt);
+
+        catalogRolloverAction.doAction(tempFile);
+
+        ArgumentCaptor<Attribute> attributeCaptor = ArgumentCaptor.forClass(Attribute.class);
+        verify(createdParentMetacard, atLeastOnce()).setAttribute(attributeCaptor.capture());
+
+        List<Attribute> geoAttributeList = attributeCaptor.getAllValues()
+                .stream()
+                .filter(attr -> attr.getName()
+                        .equals(Metacard.GEOGRAPHY))
+                .collect(Collectors.toList());
+
+        assertThat(geoAttributeList, hasSize(1));
+
+        WKTReader wktReader = new WKTReader();
+        WKTWriter wktWriter = new WKTWriter();
+
+        String unionWkt = wktWriter.write(wktReader.read(childWkt)
+                .union(wktReader.read(parentWkt))
+                .norm());
+
+        String actualWkt = (String) geoAttributeList.get(0)
+                .getValue();
+
+        assertThat(wktWriter.write(wktReader.read(actualWkt)
+                .norm()), is(unionWkt));
+
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/rollover/TestCreateMetacardRolloverAction.java
+++ b/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/rollover/TestCreateMetacardRolloverAction.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.rollover;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.io.File;
+import java.util.Collections;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import com.connexta.alliance.video.stream.mpegts.Constants;
+
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.data.impl.MetacardImpl;
+
+public class TestCreateMetacardRolloverAction {
+
+    @Test
+    public void testDoAction() throws RolloverActionException {
+        MetacardType metacardType = mock(MetacardType.class);
+        CreateMetacardRolloverAction createMetacardRolloverAction =
+                new CreateMetacardRolloverAction(Collections.singletonList(metacardType));
+        MetacardImpl metacard = createMetacardRolloverAction.doAction(null, new File("a"));
+        assertThat(metacard.getMetacardType(), is(metacardType));
+        assertThat(metacard.getContentTypeName(), Matchers.is(Constants.MPEGTS_MIME_TYPE));
+    }
+
+    @Test(expected = RolloverActionException.class)
+    public void testException() throws RolloverActionException {
+        CreateMetacardRolloverAction createMetacardRolloverAction =
+                new CreateMetacardRolloverAction(Collections.emptyList());
+        createMetacardRolloverAction.doAction(null, new File("a"));
+    }
+
+    @Test
+    public void testToString() {
+        CreateMetacardRolloverAction createMetacardRolloverAction =
+                new CreateMetacardRolloverAction(Collections.emptyList());
+        assertThat(createMetacardRolloverAction.toString(), notNullValue());
+    }
+}

--- a/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/rollover/TestElapsedTimeRolloverCondition.java
+++ b/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/rollover/TestElapsedTimeRolloverCondition.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.rollover;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.connexta.alliance.video.stream.mpegts.netty.PacketBuffer;
+
+public class TestElapsedTimeRolloverCondition {
+
+    private static final long THRESHOLD = 100;
+
+    private ElapsedTimeRolloverCondition elapsedTimeRolloverCondition;
+
+    private PacketBuffer packetBuffer;
+
+    @Before
+    public void setup() {
+        elapsedTimeRolloverCondition = new ElapsedTimeRolloverCondition(THRESHOLD);
+        packetBuffer = mock(PacketBuffer.class);
+    }
+
+    @Test
+    public void testLessThanThreshold() {
+        when(packetBuffer.getAge()).thenReturn(THRESHOLD - 1);
+        assertThat(elapsedTimeRolloverCondition.isRolloverReady(packetBuffer), is(false));
+    }
+
+    @Test
+    public void testEqualToThreshold() {
+        when(packetBuffer.getAge()).thenReturn(THRESHOLD);
+        assertThat(elapsedTimeRolloverCondition.isRolloverReady(packetBuffer), is(true));
+    }
+
+    @Test
+    public void testGreaterThanThreshold() {
+        when(packetBuffer.getAge()).thenReturn(THRESHOLD + 1);
+        assertThat(elapsedTimeRolloverCondition.isRolloverReady(packetBuffer), is(true));
+    }
+
+    @Test
+    public void testToString() {
+        assertThat(elapsedTimeRolloverCondition.toString(), notNullValue());
+    }
+
+    @Test
+    public void testAcceptVisitor() {
+        RolloverCondition.Visitor visitor = mock(RolloverCondition.Visitor.class);
+        elapsedTimeRolloverCondition.accept(visitor);
+        verify(visitor).visit(elapsedTimeRolloverCondition);
+    }
+
+    @Test
+    public void testSetter() {
+        long value = THRESHOLD - 1;
+        elapsedTimeRolloverCondition.setElapsedTimeThreshold(value);
+        assertThat(elapsedTimeRolloverCondition.getElapsedTimeThreshold(), is(value));
+    }
+}

--- a/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/rollover/TestKlvRolloverAction.java
+++ b/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/rollover/TestKlvRolloverAction.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.rollover;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.connexta.alliance.libs.klv.KlvHandler;
+import com.connexta.alliance.libs.klv.KlvProcessor;
+
+import ddf.catalog.data.impl.MetacardImpl;
+
+public class TestKlvRolloverAction {
+
+    private KlvHandler klvHandler;
+
+    private Map<String, KlvHandler> klvHandlerMap;
+
+    private Lock klvHandlerMapLock;
+
+    private Integer klvLocationSubsampleCount;
+
+    private KlvProcessor klvProcessor;
+
+    private KlvRolloverAction klvRolloverAction;
+
+    private MetacardImpl metacard;
+
+    private File tempFile;
+
+    @Before
+    public void setup() {
+        klvHandler = mock(KlvHandler.class);
+        klvHandlerMap = Collections.singletonMap("klvFieldName", klvHandler);
+        klvHandlerMapLock = mock(Lock.class);
+        klvLocationSubsampleCount = 10;
+        klvProcessor = mock(KlvProcessor.class);
+
+        metacard = mock(MetacardImpl.class);
+        tempFile = new File("a");
+
+        klvRolloverAction = new KlvRolloverAction(klvHandlerMap,
+                klvHandlerMapLock,
+                klvLocationSubsampleCount,
+                klvProcessor);
+    }
+
+    @Test
+    public void testLock() throws RolloverActionException {
+
+        klvRolloverAction.doAction(metacard, tempFile);
+
+        verify(klvHandlerMapLock).lock();
+        verify(klvHandlerMapLock).unlock();
+
+    }
+
+    @Test
+    public void testSubsampleCount() throws RolloverActionException {
+
+        klvRolloverAction.doAction(metacard, tempFile);
+
+        ArgumentCaptor<KlvProcessor.Configuration> argumentCaptor = ArgumentCaptor.forClass(
+                KlvProcessor.Configuration.class);
+
+        verify(klvProcessor).process(eq(klvHandlerMap), eq(metacard), argumentCaptor.capture());
+
+        assertThat(argumentCaptor.getValue()
+                .get(KlvProcessor.Configuration.SUBSAMPLE_COUNT), is(klvLocationSubsampleCount));
+
+    }
+
+    @Test
+    public void testHanlderResetCalled() throws RolloverActionException {
+
+        klvRolloverAction.doAction(metacard, tempFile);
+
+        verify(klvHandler).reset();
+    }
+
+}

--- a/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/rollover/TestListRolloverAction.java
+++ b/catalog/video/catalog-mpegts-stream/src/test/java/com/connexta/alliance/video/stream/mpegts/rollover/TestListRolloverAction.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p/>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p/>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.video.stream.mpegts.rollover;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
+import ddf.catalog.data.impl.MetacardImpl;
+
+public class TestListRolloverAction {
+
+    @Test
+    public void testDoAction() throws RolloverActionException {
+        RolloverAction rolloverAction1 = mock(RolloverAction.class);
+        RolloverAction rolloverAction2 = mock(RolloverAction.class);
+
+        MetacardImpl metacard = mock(MetacardImpl.class);
+        File tempFile = new File("a");
+
+        when(rolloverAction1.doAction(metacard, tempFile)).thenReturn(metacard);
+        when(rolloverAction2.doAction(metacard, tempFile)).thenReturn(metacard);
+
+        ListRolloverAction listRolloverAction =
+                new ListRolloverAction(Arrays.asList(rolloverAction1, rolloverAction2));
+
+        MetacardImpl result = listRolloverAction.doAction(metacard, tempFile);
+
+        assertThat(result, is(metacard));
+        verify(rolloverAction1).doAction(metacard, tempFile);
+        verify(rolloverAction2).doAction(metacard, tempFile);
+
+    }
+
+    @Test
+    public void testToString() {
+        assertThat(new ListRolloverAction(Collections.emptyList()).toString(), notNullValue());
+    }
+
+}

--- a/catalog/video/catalog-mpegts-transformer/pom.xml
+++ b/catalog/video/catalog-mpegts-transformer/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
-            <version>4.1</version>
+            <version>${commons-collections4.version}</version>
         </dependency>
 
         <dependency>
@@ -172,7 +172,7 @@
                             jcodec,
                             mpegts-streamer
                         </Embed-Dependency>
-                        <Export-Package/>
+                        <Export-Package>com.connexta.transformer.video</Export-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/catalog/video/catalog-video-app/src/main/resources/features.xml
+++ b/catalog/video/catalog-video-app/src/main/resources/features.xml
@@ -16,16 +16,29 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
 
-    <feature name="video-app" install="auto" version="${project.version}"
-             description="The Alliance Video Application provides support for ingesting and searching for MPEG-TS products.  ::Alliance Video">
-        <feature prerequisite="true">catalog-app</feature>
-        <feature prerequisite="true">catalog-core-validator</feature>
-        <bundle>mvn:com.connexta.alliance/stanag4609/${project.version}</bundle>
-        <bundle>mvn:com.connexta.alliance/klv/${project.version}</bundle>
-        <bundle>mvn:org.codice.ddf/klv/${ddf.version}</bundle>
-        <bundle>mvn:org.codice.ddf/mpeg-transport-stream/${ddf.version}</bundle>
+    <feature name="mpegts-stream" install="auto" version="${project.version}"
+             description="Consume UDP MPEG-TS Stream">
+        <feature prerequisite="true">alliance-video-app</feature>
+        <bundle>mvn:com.connexta.alliance.video/alliance-mpegts-transformer/${project.version}</bundle>
+        <bundle>mvn:com.connexta.alliance.video/alliance-mpegts-stream/${project.version}</bundle>
+    </feature>
+
+    <feature name="mpegts-input-transformer" install="auto" version="${project.version}"
+             description="Transform MPEG-TS Files">
+        <feature prerequisite="true">alliance-video-app</feature>
         <bundle>mvn:com.connexta.alliance.video/alliance-mpegts-transformer/${project.version}</bundle>
         <configfile finalname="/etc/DDF_Custom_Mime_Type_Resolver.mpegts.config">mvn:com.connexta.alliance.video/alliance-mpegts-transformer/${project.version}/config/mpegts</configfile>
         <configfile finalname="/etc/definitions/MpegTsMetacardType.json">mvn:com.connexta.alliance.video/alliance-mpegts-transformer/${project.version}/json/mpegts</configfile>
     </feature>
+
+    <feature name="alliance-video-app" install="auto" version="${project.version}"
+             description="The Alliance Video Application provides support for ingesting and searching for MPEG-TS products.">
+        <feature prerequisite="true">catalog-app</feature>
+        <feature prerequisite="true">catalog-core-validator</feature>
+        <bundle>mvn:org.codice.ddf/klv/${ddf.version}</bundle>
+        <bundle>mvn:org.codice.ddf/mpeg-transport-stream/${ddf.version}</bundle>
+        <bundle>mvn:com.connexta.alliance/stanag4609/${project.version}</bundle>
+        <bundle>mvn:com.connexta.alliance/klv/${project.version}</bundle>
+    </feature>
+    
 </features>

--- a/catalog/video/pom.xml
+++ b/catalog/video/pom.xml
@@ -27,6 +27,7 @@
     <name>Alliance :: Video</name>
 
     <modules>
+        <module>catalog-mpegts-stream</module>
         <module>catalog-mpegts-transformer</module>
         <module>catalog-video-app</module>
     </modules>

--- a/distribution/install-profiles/src/main/resources/features.xml
+++ b/distribution/install-profiles/src/main/resources/features.xml
@@ -51,7 +51,7 @@
         <!-- Experimental Apps-->
         <feature>resourcemanagement-app</feature>
         <feature>geowebcache-app</feature>
-        <feature>video-app</feature>
+        <feature>alliance-video-app</feature>
     </feature>
 
 </features>

--- a/libs/klv/pom.xml
+++ b/libs/klv/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
-            <version>4.1</version>
+            <version>${commons-collections4.version}</version>
         </dependency>
 
         <dependency>

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/GeoBoxHandler.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/GeoBoxHandler.java
@@ -169,6 +169,11 @@ class GeoBoxHandler extends BaseKlvHandler {
                 ((KlvIntegerEncodedFloatingPoint) klvDataElement).getValue());
     }
 
+    @Override
+    public void reset() {
+        map.clear();
+    }
+
     public void accept(String name, Double value) {
         map.putIfAbsent(name, new ArrayList<>());
         map.get(name)

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/GeometryUtility.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/GeometryUtility.java
@@ -25,7 +25,7 @@ import com.vividsolutions.jts.io.WKTWriter;
 
 import ddf.catalog.data.Attribute;
 
-class GeometryUtility {
+public class GeometryUtility {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GeometryUtility.class);
 

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/KlvHandler.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/KlvHandler.java
@@ -49,4 +49,9 @@ public interface KlvHandler {
      */
     void accept(KlvDataElement klvDataElement);
 
+    /**
+     * Reset the handler to its initial state.
+     */
+    void reset();
+
 }

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/LatitudeLongitudeHandler.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/LatitudeLongitudeHandler.java
@@ -95,4 +95,9 @@ class LatitudeLongitudeHandler extends BaseKlvHandler {
                 .add(((KlvIntegerEncodedFloatingPoint) klvDataElement).getValue());
     }
 
+    @Override
+    public void reset() {
+        map.clear();
+    }
+
 }

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/ListOfBasicKlvDataTypesHandler.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/ListOfBasicKlvDataTypesHandler.java
@@ -62,4 +62,10 @@ class ListOfBasicKlvDataTypesHandler<T extends Serializable> extends BaseKlvHand
         list.add(clazz.cast(klvDataElement)
                 .getValue());
     }
+
+    @Override
+    public void reset() {
+        list.clear();
+    }
+
 }

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/ListOfDatesHandler.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/ListOfDatesHandler.java
@@ -55,4 +55,10 @@ class ListOfDatesHandler extends BaseKlvHandler {
         }
         dateList.add(new Date(TimeUnit.MICROSECONDS.toMillis(((KlvLong) klvDataElement).getValue())));
     }
+
+    @Override
+    public void reset() {
+        dateList.clear();
+    }
+
 }

--- a/libs/klv/src/main/java/com/connexta/alliance/libs/klv/LoggingKlvHandler.java
+++ b/libs/klv/src/main/java/com/connexta/alliance/libs/klv/LoggingKlvHandler.java
@@ -41,4 +41,10 @@ public class LoggingKlvHandler implements KlvHandler {
                 klvDataElement.getName(),
                 klvDataElement);
     }
+
+    @Override
+    public void reset() {
+
+    }
+
 }

--- a/libs/stanag4609/pom.xml
+++ b/libs/stanag4609/pom.xml
@@ -102,7 +102,7 @@
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.90</minimum>
+                                            <minimum>0.88</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>

--- a/libs/stanag4609/src/main/java/com/connexta/alliance/libs/stanag4609/PESUtilities.java
+++ b/libs/stanag4609/src/main/java/com/connexta/alliance/libs/stanag4609/PESUtilities.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Connexta, LLC
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.alliance.libs.stanag4609;
+
+import java.nio.ByteBuffer;
+
+import org.codice.ddf.libs.klv.KlvDecoder;
+import org.codice.ddf.libs.klv.KlvDecodingException;
+import org.jcodec.containers.mps.MPSDemuxer;
+import org.jcodec.containers.mps.MPSUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PESUtilities {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PESUtilities.class);
+
+    private static final int METADATA_STREAM_ID = 0xFC;
+
+    private static final int PRIVATE_STREAM_ID = 0xBD;
+
+    public static DecodedKLVMetadataPacket handlePESPacketBytes(final byte[] pesPacketBytes,  KlvDecoder decoder)
+            throws KlvDecodingException {
+        final MPSDemuxer.PESPacket pesHeader = MPSUtils.readPESHeader(ByteBuffer.wrap(pesPacketBytes), 0);
+
+        if (pesHeader.streamId == METADATA_STREAM_ID) {
+            return new SynchronousMetadataPacket(pesPacketBytes, pesHeader, decoder).decodeKLV();
+        } else if (pesHeader.streamId == PRIVATE_STREAM_ID) {
+            return new AsynchronousMetadataPacket(pesPacketBytes, pesHeader, decoder).decodeKLV();
+        } else {
+            LOGGER.debug("Unknown stream type {}. Skipping this packet.", pesHeader.streamId);
+        }
+        return null;
+    }
+
+}

--- a/libs/stanag4609/src/main/java/com/connexta/alliance/libs/stanag4609/Stanag4609TransportStreamParser.java
+++ b/libs/stanag4609/src/main/java/com/connexta/alliance/libs/stanag4609/Stanag4609TransportStreamParser.java
@@ -16,7 +16,6 @@ package com.connexta.alliance.libs.stanag4609;
 import static org.codice.ddf.libs.klv.data.Klv.KeyLength;
 import static org.codice.ddf.libs.klv.data.Klv.LengthEncoding;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -35,8 +34,6 @@ import org.codice.ddf.libs.klv.data.numerical.KlvUnsignedShort;
 import org.codice.ddf.libs.klv.data.set.KlvLocalSet;
 import org.codice.ddf.libs.klv.data.text.KlvString;
 import org.codice.ddf.libs.mpeg.transport.MpegTransportStreamMetadataExtractor;
-import org.jcodec.containers.mps.MPSDemuxer.PESPacket;
-import org.jcodec.containers.mps.MPSUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -365,15 +362,6 @@ public class Stanag4609TransportStreamParser {
 
     private DecodedKLVMetadataPacket handlePESPacketBytes(final byte[] pesPacketBytes)
             throws KlvDecodingException {
-        final PESPacket pesHeader = MPSUtils.readPESHeader(ByteBuffer.wrap(pesPacketBytes), 0);
-
-        if (pesHeader.streamId == METADATA_STREAM_ID) {
-            return new SynchronousMetadataPacket(pesPacketBytes, pesHeader, decoder).decodeKLV();
-        } else if (pesHeader.streamId == PRIVATE_STREAM_ID) {
-            return new AsynchronousMetadataPacket(pesPacketBytes, pesHeader, decoder).decodeKLV();
-        } else {
-            LOGGER.debug("Unknown stream type {}. Skipping this packet.", pesHeader.streamId);
-        }
-        return null;
+        return PESUtilities.handlePESPacketBytes(pesPacketBytes, decoder);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <maven.release.plugin.version>2.5.1</maven.release.plugin.version>
         <jcodec.version>0.2.0_1</jcodec.version>
         <mpegts-streamer.version>0.1.0_1</mpegts-streamer.version>
+        <commons-collections4.version>4.1</commons-collections4.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
#### What does this PR do?
Ingest MPEG-TS UDP Stream data.

#### Who is reviewing it?
@beyelerb @jrnorth @kcwire @rzwiefel 
#### How should this be tested?
Deploy the alliance-video-app to DDF. With the admin UI, go the Alliance Video App panel => Configuration => MPEG-TS UDP Stream Monitor. The default values are acceptable. Find the test code MpegTsUdpClient in alliance-mpegts-stream. Go to line 90 and adjust to the path to your local copy of 1003-GBR-IRL-SIT-H450-clip02-1003_OS.ts. (I know, this test app needs to be improved!) Every 30 seconds or so, the ddf log file should indicate that a new chunk is being stored. A ddf search should find the chunks and a parent metacard for the stream.
  
#### Any background context you want to provide?
I want to add some more unit tests, and to make sure the attributes temporal.start and temporal.end are being supplied by the MPEG-TS input transformer. But I wanted to make the code available for review because it is a large amount of code.

All of the files in libs/klv are just refactored code from alliance-mpegts-transformer. The refactoring occurred in CAL-29, but had to merged into this branch as well. 

#### What are the relevant tickets?

#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

Listen for UDP packets that contain MPEG-TS packets. Create a parent metacard for that
represents the stream. Break the data stream into chunks (based on elapsed time and
size) and store those chunks in the catalog. Each chunk's metacard is linked to the
parent metacard.