### PR TITLE
CAL-37: Set AccessCriteria fields in NSILI Source

### DIFF
--- a/catalog/nsili/catalog-nsili-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/nsili/catalog-nsili-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -62,6 +62,10 @@
             <property name="cxfPassword" value=""/>
             <property name="pollInterval" value="5"/>
             <property name="maxHitCount" value="250"/>
+            <property name="accessUserId" value="" />
+            <property name="accessPassword" value="" />
+            <property name="accessLicenseKey" value="" />
+            <property name="excludeSortOrder" value="false" />
             <property name="filterAdapter" ref="filterAdapter"/>
             <property name="resourceReader" ref="urlReader"/>
         </cm:managed-component>
@@ -82,6 +86,10 @@
             <property name="cxfPassword" value=""/>
             <property name="pollInterval" value="5"/>
             <property name="maxHitCount" value="250"/>
+            <property name="accessUserId" value="" />
+            <property name="accessPassword" value="" />
+            <property name="accessLicenseKey" value="" />
+            <property name="excludeSortOrder" value="false" />
             <property name="filterAdapter" ref="filterAdapter"/>
             <property name="resourceReader" ref="urlReader"/>
         </cm:managed-component>

--- a/catalog/nsili/catalog-nsili-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/nsili/catalog-nsili-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -20,7 +20,7 @@
         <AD description="The ID of the NSILI Source" name="NSILI Source ID" id="id"
             required="true" type="String" default="NSILI Federated Source"/>
 
-        <AD description="The URL of the IOR File to use for the NSILI CORBA Server.  For local files, use 'file://'"
+        <AD description="The URL of the IOR File to use for the NSILI CORBA Service.  For local files, use 'file://'"
             name="Ior File URL" id="iorUrl" required="true" type="String"/>
 
         <AD description="The Username to be used for authentication with HTTP server."
@@ -36,6 +36,18 @@
         <AD description="Poll Interval to Check if the Source is available (in minutes - minimum 1)."
             name="Poll Interval" id="pollInterval"
             required="true" type="Integer" default="5"/>
+
+        <AD description="Whether or not to exclude sort order in query."
+            name="Exclude Sort Order" id="excludeSortOrder" required="false" type="Boolean" default="false"/>
+
+        <AD description="User ID for NSILI Access Criteria"
+            name="NSILI Access Criteria User" id="accessUserId" required="false" type="String" default=""/>
+
+        <AD description="Password for NSILI Access Criteria"
+            name="NSILI Access Criteria Password" id="accessPassword" required="false" type="String" default=""/>
+
+        <AD description="License Key for NSILI Access Criteria"
+            name="NSILI Access Criteria License Key" id="accessLicenseKey" required="false" type="String" default=""/>
     </OCD>
 
     <OCD name="NSILI Connected Source" id="NSILI_Connected_Source"
@@ -44,7 +56,7 @@
         <AD description="The ID of the NSILI Source" name="NSILI Source ID" id="id"
             required="true" type="String" default="NSILI Connected Source"/>
 
-        <AD description="The URL of the IOR File to use for the NSILI CORBA Server.  For local files, use 'file://'"
+        <AD description="The URL of the IOR File to use for the NSILI CORBA Service.  For local files, use 'file://'"
             name="Ior File URL" id="iorUrl" required="true" type="String"/>
 
         <AD description="The Username to be used for authentication with HTTP server."
@@ -60,6 +72,18 @@
         <AD description="Poll Interval to Check if the Source is available (in minutes - minimum 1)."
             name="Poll Interval" id="pollInterval"
             required="true" type="Integer" default="5"/>
+
+        <AD description="Whether or not to exclude sort order in query."
+            name="Exclude Sort Order" id="excludeSortOrder" required="false" type="Boolean" default="false"/>
+
+        <AD description="User ID for NSILI Access Criteria"
+            name="NSILI Access Criteria User" id="accessUserId" required="false" type="String" default=""/>
+
+        <AD description="Password for NSILI Access Criteria"
+            name="NSILI Access Criteria Password" id="accessPassword" required="false" type="String" default=""/>
+
+        <AD description="License Key for NSILI Access Criteria"
+            name="NSILI Access Criteria License Key" id="accessLicenseKey" required="false" type="String" default=""/>
     </OCD>
 
     <Designate pid="NSILI_Federated_Source" factoryPid="NSILI_Federated_Source">

--- a/catalog/nsili/catalog-nsili-transformer/src/main/java/com/connexta/alliance/nsili/transformer/DAGConverter.java
+++ b/catalog/nsili/catalog-nsili-transformer/src/main/java/com/connexta/alliance/nsili/transformer/DAGConverter.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang.StringUtils;
 import org.jgrapht.alg.DijkstraShortestPath;
 import org.jgrapht.experimental.dag.DirectedAcyclicGraph;
 import org.jgrapht.traverse.DepthFirstIterator;
@@ -303,7 +304,10 @@ public class DAGConverter {
     protected static void addNsilCardAttribute(MetacardImpl metacard, Node node) {
         switch (node.attribute_name) {
         case NsiliConstants.IDENTIFIER:
-            metacard.setId(getString(node.value));
+            if (StringUtils.isBlank(metacard.getId())) {
+                //Only use this ID if nothing is set, otherwise we can ignore it
+                metacard.setId(getString(node.value));
+            }
             break;
         case NsiliConstants.SOURCE_DATE_TIME_MODIFIED:
             Date cardDate = convertDate(node.value);

--- a/catalog/nsili/catalog-nsili-transformer/src/test/java/com/connexta/alliance/nsili/transformer/TestDAGConverter.java
+++ b/catalog/nsili/catalog-nsili-transformer/src/test/java/com/connexta/alliance/nsili/transformer/TestDAGConverter.java
@@ -345,7 +345,7 @@ public class TestDAGConverter {
                         .getClass()
                         .getCanonicalName()));
         assertThat(FILE_TITLE, is(metacard.getTitle()));
-        assertThat(CARD_ID, is(metacard.getId()));
+        assertThat(COM_ID_UUID, is(metacard.getId()));
         assertThat(NsiliProductType.IMAGERY.toString(), is(metacard.getContentTypeName()));
         assertThat(FILE_FORMAT_VER, is(metacard.getContentTypeVersion()));
         assertThat(metacard.getCreatedDate(), notNullValue());
@@ -657,7 +657,7 @@ public class TestDAGConverter {
                 is(metacard.getMetacardType()
                         .getClass()
                         .getCanonicalName()));
-        assertThat(CARD_ID, is(metacard.getId()));
+        assertThat(COM_ID_UUID, is(metacard.getId()));
         assertThat(NsiliProductType.GMTI.toString(), is(metacard.getContentTypeName()));
         assertThat(STREAM_STANDARD_VER, is(metacard.getContentTypeVersion()));
         assertThat(metacard.getCreatedDate(), notNullValue());
@@ -755,7 +755,7 @@ public class TestDAGConverter {
                         .getClass()
                         .getCanonicalName()));
         assertThat(MESSAGE_SUBJECT, is(metacard.getTitle()));
-        assertThat(CARD_ID, is(metacard.getId()));
+        assertThat(COM_ID_UUID, is(metacard.getId()));
         assertThat(NsiliProductType.MESSAGE.toString(), is(metacard.getContentTypeName()));
         assertThat(metacard.getContentTypeVersion(), nullValue());
         assertThat(metacard.getCreatedDate(), notNullValue());
@@ -855,7 +855,7 @@ public class TestDAGConverter {
                         .getClass()
                         .getCanonicalName()));
         assertThat(FILE_TITLE, is(metacard.getTitle()));
-        assertThat(CARD_ID, is(metacard.getId()));
+        assertThat(COM_ID_UUID, is(metacard.getId()));
         assertThat(NsiliProductType.VIDEO.toString(), is(metacard.getContentTypeName()));
         assertThat(metacard.getContentTypeVersion(), nullValue());
         assertThat(metacard.getCreatedDate(), notNullValue());
@@ -1146,7 +1146,7 @@ public class TestDAGConverter {
                         .getClass()
                         .getCanonicalName()));
         assertThat(FILE_TITLE, is(metacard.getTitle()));
-        assertThat(CARD_ID, is(metacard.getId()));
+        assertThat(COM_ID_UUID, is(metacard.getId()));
         assertThat(NsiliProductType.REPORT.toString(), is(metacard.getContentTypeName()));
         assertThat(FILE_FORMAT_VER, is(metacard.getContentTypeVersion()));
         assertThat(metacard.getCreatedDate(), notNullValue());
@@ -1253,7 +1253,7 @@ public class TestDAGConverter {
                         .getClass()
                         .getCanonicalName()));
         assertThat(FILE_TITLE, is(metacard.getTitle()));
-        assertThat(CARD_ID, is(metacard.getId()));
+        assertThat(COM_ID_UUID, is(metacard.getId()));
         assertThat(NsiliProductType.COLLECTION_EXPLOITATION_PLAN.toString(),
                 is(metacard.getContentTypeName()));
         assertThat(FILE_FORMAT_VER, is(metacard.getContentTypeVersion()));
@@ -1348,7 +1348,7 @@ public class TestDAGConverter {
                         .getClass()
                         .getCanonicalName()));
         assertThat(FILE_TITLE, is(metacard.getTitle()));
-        assertThat(CARD_ID, is(metacard.getId()));
+        assertThat(COM_ID_UUID, is(metacard.getId()));
         assertThat(NsiliProductType.DOCUMENT.toString(), is(metacard.getContentTypeName()));
         assertThat(FILE_FORMAT_VER, is(metacard.getContentTypeVersion()));
         assertThat(metacard.getCreatedDate(), notNullValue());
@@ -1438,7 +1438,7 @@ public class TestDAGConverter {
                         .getClass()
                         .getCanonicalName()));
         assertThat(FILE_TITLE, is(metacard.getTitle()));
-        assertThat(CARD_ID, is(metacard.getId()));
+        assertThat(COM_ID_UUID, is(metacard.getId()));
         assertThat(NsiliProductType.RFI.toString(), is(metacard.getContentTypeName()));
         assertThat(FILE_FORMAT_VER, is(metacard.getContentTypeVersion()));
         assertThat(metacard.getCreatedDate(), notNullValue());
@@ -1556,7 +1556,7 @@ public class TestDAGConverter {
                         .getClass()
                         .getCanonicalName()));
         assertThat(FILE_TITLE, is(metacard.getTitle()));
-        assertThat(CARD_ID, is(metacard.getId()));
+        assertThat(COM_ID_UUID, is(metacard.getId()));
         assertThat(NsiliProductType.TASK.toString(), is(metacard.getContentTypeName()));
         assertThat(FILE_FORMAT_VER, is(metacard.getContentTypeVersion()));
         assertThat(metacard.getCreatedDate(), notNullValue());
@@ -1657,7 +1657,7 @@ public class TestDAGConverter {
                         .getClass()
                         .getCanonicalName()));
         assertThat(FILE_TITLE, is(metacard.getTitle()));
-        assertThat(CARD_ID, is(metacard.getId()));
+        assertThat(COM_ID_UUID, is(metacard.getId()));
         assertThat(NsiliProductType.TDL_DATA.toString(), is(metacard.getContentTypeName()));
         assertThat(FILE_FORMAT_VER, is(metacard.getContentTypeVersion()));
         assertThat(metacard.getCreatedDate(), notNullValue());
@@ -1899,8 +1899,7 @@ public class TestDAGConverter {
             ResultDAGConverter.addStringAttribute(graph,
                     cardNode,
                     NsiliConstants.IDENTIFIER,
-                    UUID.randomUUID()
-                            .toString(),
+                    CARD_ID,
                     orb);
             addTestDateAttribute(graph, cardNode, NsiliConstants.SOURCE_DATE_TIME_MODIFIED, orb);
             addTestDateAttribute(graph, cardNode, NsiliConstants.DATE_TIME_MODIFIED, orb);


### PR DESCRIPTION
#### What does this PR do?
Allows the NSILI source configuration to specify AccessCriteria fields (user/pass/license key).
Changes queries to only set SortAttributes if the query will return more than 1 result
#### Who is reviewing it?
@jaymcnallie @bdeining @dcruver 
#### How should this be tested?
Configure NSILI Federated Source in Admin UI and verify user/pass/license key fields are present.
Build and run JUnit tests
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/CAL-37
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
