### PR TITLE
CAL-39 : Update NSILI Source to retrieve thumbnails during DAG conversion

### DIFF
--- a/catalog/nsili/catalog-nsili-common/src/main/java/com/connexta/alliance/nsili/common/NsiliConstants.java
+++ b/catalog/nsili/catalog-nsili-common/src/main/java/com/connexta/alliance/nsili/common/NsiliConstants.java
@@ -281,7 +281,7 @@ public class NsiliConstants {
 
     public static final String FILE_TYPE = "fileType";
 
-    public static final String URL = "url";
+    public static final String URL = "URL";
 
     public static final String CONTRIBUTOR = "contributor";
 
@@ -299,5 +299,8 @@ public class NsiliConstants {
     public static final String ORIGINATING_FROM = "ORIGINATING FROM";
 
     public static final String FOLLOWS = "FOLLOWS";
+
+    //Related File
+    public static final String THUMBNAIL_TYPE = "THUMBNAIL";
 
 }

--- a/catalog/nsili/catalog-nsili-endpoint/src/main/java/com/connexta/alliance/nsili/endpoint/NsiliWebEndpoint.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/main/java/com/connexta/alliance/nsili/endpoint/NsiliWebEndpoint.java
@@ -43,9 +43,10 @@ public class NsiliWebEndpoint implements NsiliWeb {
     @Override
     @GET
     @Path("ior.txt")
-    @Produces(MediaType.TEXT_PLAIN)
+    @Produces("text/plain; charset=ISO-8859-1")
     public Response getIorFile() {
-        Response.ResponseBuilder response = Response.ok(nsiliEndpoint.getIorString());
+        String responseStr = nsiliEndpoint.getIorString() + "\n";
+        Response.ResponseBuilder response = Response.ok(responseStr);
         return response.build();
     }
 }

--- a/catalog/nsili/catalog-nsili-endpoint/src/test/java/com/connexta/alliance/nsili/endpoint/TestNsiliWebEndpoint.java
+++ b/catalog/nsili/catalog-nsili-endpoint/src/test/java/com/connexta/alliance/nsili/endpoint/TestNsiliWebEndpoint.java
@@ -13,7 +13,7 @@
  */
 package com.connexta.alliance.nsili.endpoint;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
@@ -46,7 +46,7 @@ public class TestNsiliWebEndpoint extends TestNsiliCommon {
         assertThat(response.getEntity(), notNullValue());
 
         String responseStr = response.getEntity().toString();
-        assertThat(responseStr, is(nsiliEndpoint.getIorString()));
+        assertThat(responseStr, containsString(nsiliEndpoint.getIorString()));
     }
 
     @After

--- a/catalog/nsili/catalog-nsili-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/nsili/catalog-nsili-source/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -62,6 +62,7 @@
             <property name="cxfPassword" value=""/>
             <property name="pollInterval" value="5"/>
             <property name="maxHitCount" value="250"/>
+            <property name="numberWorkerThreads" value="4" />
             <property name="accessUserId" value="" />
             <property name="accessPassword" value="" />
             <property name="accessLicenseKey" value="" />
@@ -86,6 +87,7 @@
             <property name="cxfPassword" value=""/>
             <property name="pollInterval" value="5"/>
             <property name="maxHitCount" value="250"/>
+            <property name="numberWorkerThreads" value="4" />
             <property name="accessUserId" value="" />
             <property name="accessPassword" value="" />
             <property name="accessLicenseKey" value="" />

--- a/catalog/nsili/catalog-nsili-source/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/nsili/catalog-nsili-source/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -37,6 +37,9 @@
             name="Poll Interval" id="pollInterval"
             required="true" type="Integer" default="5"/>
 
+        <AD description="Maximum parallel threads for converting results and retrieving thumbnails" name="Num Worker Threads"
+            id="numberWorkerThreads" required="true" type="Integer" default="4"/>
+
         <AD description="Whether or not to exclude sort order in query."
             name="Exclude Sort Order" id="excludeSortOrder" required="false" type="Boolean" default="false"/>
 
@@ -75,6 +78,9 @@
         <AD description="Poll Interval to Check if the Source is available (in minutes - minimum 1)."
             name="Poll Interval" id="pollInterval"
             required="true" type="Integer" default="5"/>
+
+        <AD description="Maximum parallel threads for converting results and retrieving thumbnails" name="Num Worker Threads"
+            id="numberWorkerThreads" required="true" type="Integer" default="4"/>
 
         <AD description="Whether or not to exclude sort order in query."
             name="Exclude Sort Order" id="excludeSortOrder" required="false" type="Boolean" default="false"/>

--- a/catalog/nsili/catalog-nsili-source/src/test/java/com/connexta/alliance/nsili/source/TestNsiliSource.java
+++ b/catalog/nsili/catalog-nsili-source/src/test/java/com/connexta/alliance/nsili/source/TestNsiliSource.java
@@ -363,6 +363,7 @@ public class TestNsiliSource {
         source.setDataModelMgr(getMockDataModelMgr());
         source.setCatalogMgr(getMockCatalogMgr());
         source.setFilterAdapter(new GeotoolsFilterAdapterImpl());
+        source.setNumberWorkerThreads(6);
 
         // Suppress CORBA communications to test refresh
         doNothing().when(source)

--- a/catalog/nsili/catalog-nsili-transformer/pom.xml
+++ b/catalog/nsili/catalog-nsili-transformer/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>jts</artifactId>
             <version>1.12</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-urlresourcereader</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/catalog/nsili/catalog-nsili-transformer/src/test/java/com/connexta/alliance/nsili/transformer/TestDAGConverter.java
+++ b/catalog/nsili/catalog-nsili-transformer/src/test/java/com/connexta/alliance/nsili/transformer/TestDAGConverter.java
@@ -17,6 +17,10 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 import java.io.File;
 import java.io.IOException;
@@ -80,6 +84,9 @@ import ddf.catalog.data.AttributeDescriptor;
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.MetacardType;
 import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.operation.ResourceResponse;
+import ddf.catalog.resource.Resource;
+import ddf.catalog.resource.impl.URLResourceReader;
 
 public class TestDAGConverter {
 
@@ -261,10 +268,14 @@ public class TestDAGConverter {
 
     private Calendar cal;
 
+    private DAGConverter dagConverter;
+
+    private URLResourceReader mockResourceReader = mock(URLResourceReader.class);
+    
     private static final boolean SHOULD_PRINT_CARD = false;
 
     @Before
-    public void setUp() {
+    public void setUp() throws Exception {
         this.orb = ORB.init();
 
         int year = 2016;
@@ -274,6 +285,9 @@ public class TestDAGConverter {
         int minute = 05;
         int second = 10;
         cal = new GregorianCalendar(year, month, dayOfMonth, hourOfDay, minute, second);
+        dagConverter = new DAGConverter(mockResourceReader);
+
+        setupMocks();
     }
 
     /**
@@ -316,6 +330,7 @@ public class TestDAGConverter {
         addAssocationNode(graph, productNode);
         addApprovalNode(graph, productNode);
         addSdsNode(graph, productNode);
+        addRelatedFile(graph, productNode);
 
         graph.addVertex(productNode);
 
@@ -324,7 +339,7 @@ public class TestDAGConverter {
         imageryDAG.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
         imageryDAG.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
 
-        MetacardImpl metacard = DAGConverter.convertDAG(imageryDAG, false, SOURCE_ID);
+        MetacardImpl metacard = dagConverter.convertDAG(imageryDAG, false, SOURCE_ID);
 
         if (SHOULD_PRINT_CARD) {
             File file = new File("/tmp/output-imagery.txt");
@@ -393,7 +408,7 @@ public class TestDAGConverter {
         imageryDAG.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
         imageryDAG.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
 
-        MetacardImpl metacard = DAGConverter.convertDAG(imageryDAG, true, SOURCE_ID);
+        MetacardImpl metacard = dagConverter.convertDAG(imageryDAG, true, SOURCE_ID);
 
         if (SHOULD_PRINT_CARD) {
             File file = new File("/tmp/output-imagery.txt");
@@ -683,7 +698,7 @@ public class TestDAGConverter {
         dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
         dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
 
-        MetacardImpl metacard = DAGConverter.convertDAG(dag, false, SOURCE_ID);
+        MetacardImpl metacard = dagConverter.convertDAG(dag, false, SOURCE_ID);
 
         if (SHOULD_PRINT_CARD) {
             File file = new File("/tmp/output-gmti.txt");
@@ -780,7 +795,7 @@ public class TestDAGConverter {
         dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
         dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
 
-        MetacardImpl metacard = DAGConverter.convertDAG(dag, false, SOURCE_ID);
+        MetacardImpl metacard = dagConverter.convertDAG(dag, false, SOURCE_ID);
 
         if (SHOULD_PRINT_CARD) {
             File file = new File("/tmp/output-message.txt");
@@ -880,7 +895,7 @@ public class TestDAGConverter {
         dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
         dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
 
-        MetacardImpl metacard = DAGConverter.convertDAG(dag, false, SOURCE_ID);
+        MetacardImpl metacard = dagConverter.convertDAG(dag, false, SOURCE_ID);
 
         if (SHOULD_PRINT_CARD) {
             File file = new File("/tmp/output-video.txt");
@@ -936,7 +951,7 @@ public class TestDAGConverter {
         dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
         dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
 
-        MetacardImpl metacard = DAGConverter.convertDAG(dag, false, SOURCE_ID);
+        MetacardImpl metacard = dagConverter.convertDAG(dag, false, SOURCE_ID);
         assertThat(metacard.getTitle(), nullValue());
     }
 
@@ -961,7 +976,7 @@ public class TestDAGConverter {
         dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
         dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
 
-        MetacardImpl metacard = DAGConverter.convertDAG(dag, false, SOURCE_ID);
+        MetacardImpl metacard = dagConverter.convertDAG(dag, false, SOURCE_ID);
         assertThat(metacard.getTitle(), nullValue());
     }
 
@@ -990,7 +1005,7 @@ public class TestDAGConverter {
         dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
         dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
 
-        MetacardImpl metacard = DAGConverter.convertDAG(dag, false, SOURCE_ID);
+        MetacardImpl metacard = dagConverter.convertDAG(dag, false, SOURCE_ID);
         assertThat(metacard.getTitle(), nullValue());
     }
 
@@ -1015,14 +1030,14 @@ public class TestDAGConverter {
         dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
         dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
 
-        MetacardImpl metacard = DAGConverter.convertDAG(dag, false, SOURCE_ID);
+        MetacardImpl metacard = dagConverter.convertDAG(dag, false, SOURCE_ID);
         assertThat(metacard.getTitle(), nullValue());
     }
 
     @Test
     public void testEmptyDAG() {
         DAG dag = new DAG();
-        MetacardImpl metacard = DAGConverter.convertDAG(dag, false, SOURCE_ID);
+        MetacardImpl metacard = dagConverter.convertDAG(dag, false, SOURCE_ID);
         assertThat(metacard, nullValue());
     }
 
@@ -1037,7 +1052,7 @@ public class TestDAGConverter {
 
         dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
 
-        MetacardImpl metacard = DAGConverter.convertDAG(dag, false, SOURCE_ID);
+        MetacardImpl metacard = dagConverter.convertDAG(dag, false, SOURCE_ID);
         assertThat(metacard, nullValue());
     }
 
@@ -1056,7 +1071,7 @@ public class TestDAGConverter {
         dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
         dag.edges = edges;
 
-        MetacardImpl metacard = DAGConverter.convertDAG(dag, false, SOURCE_ID);
+        MetacardImpl metacard = dagConverter.convertDAG(dag, false, SOURCE_ID);
         assertThat(metacard.getTitle(), nullValue());
     }
 
@@ -1075,7 +1090,7 @@ public class TestDAGConverter {
         dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
         dag.edges = edges;
 
-        MetacardImpl metacard = DAGConverter.convertDAG(dag, false, SOURCE_ID);
+        MetacardImpl metacard = dagConverter.convertDAG(dag, false, SOURCE_ID);
         assertThat(metacard.getTitle(), nullValue());
     }
 
@@ -1171,7 +1186,7 @@ public class TestDAGConverter {
         dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
         dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
 
-        MetacardImpl metacard = DAGConverter.convertDAG(dag, false, SOURCE_ID);
+        MetacardImpl metacard = dagConverter.convertDAG(dag, false, SOURCE_ID);
 
         if (SHOULD_PRINT_CARD) {
             File file = new File("/tmp/output-report.txt");
@@ -1278,7 +1293,7 @@ public class TestDAGConverter {
         dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
         dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
 
-        MetacardImpl metacard = DAGConverter.convertDAG(dag, false, SOURCE_ID);
+        MetacardImpl metacard = dagConverter.convertDAG(dag, false, SOURCE_ID);
 
         if (SHOULD_PRINT_CARD) {
             File file = new File("/tmp/output-ccirm-cxp.txt");
@@ -1373,7 +1388,7 @@ public class TestDAGConverter {
         dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
         dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
 
-        MetacardImpl metacard = DAGConverter.convertDAG(dag, false, SOURCE_ID);
+        MetacardImpl metacard = dagConverter.convertDAG(dag, false, SOURCE_ID);
 
         if (SHOULD_PRINT_CARD) {
             File file = new File("/tmp/output-ccirm-ir.txt");
@@ -1463,7 +1478,7 @@ public class TestDAGConverter {
         dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
         dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
 
-        MetacardImpl metacard = DAGConverter.convertDAG(dag, false, SOURCE_ID);
+        MetacardImpl metacard = dagConverter.convertDAG(dag, false, SOURCE_ID);
 
         if (SHOULD_PRINT_CARD) {
             File file = new File("/tmp/output-ccirm-rfi.txt");
@@ -1581,7 +1596,7 @@ public class TestDAGConverter {
         dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
         dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
 
-        MetacardImpl metacard = DAGConverter.convertDAG(dag, false, SOURCE_ID);
+        MetacardImpl metacard = dagConverter.convertDAG(dag, false, SOURCE_ID);
 
         if (SHOULD_PRINT_CARD) {
             File file = new File("/tmp/output-ccirm-task.txt");
@@ -1682,7 +1697,7 @@ public class TestDAGConverter {
         dag.edges = NsiliCommonUtils.getEdgeArrayFromGraph(graph);
         dag.nodes = NsiliCommonUtils.getNodeArrayFromGraph(graph);
 
-        MetacardImpl metacard = DAGConverter.convertDAG(dag, false, SOURCE_ID);
+        MetacardImpl metacard = dagConverter.convertDAG(dag, false, SOURCE_ID);
 
         if (SHOULD_PRINT_CARD) {
             File file = new File("/tmp/output-tdl.txt");
@@ -1821,6 +1836,40 @@ public class TestDAGConverter {
                 fileNode,
                 NsiliConstants.TITLE,
                 FILE_TITLE,
+                orb);
+    }
+
+    private void addRelatedFile(DirectedAcyclicGraph<Node, Edge> graph, Node productNode) {
+        Any any = orb.create_any();
+        Node relatedFileNode = new Node(0, NodeType.ENTITY_NODE, NsiliConstants.NSIL_RELATED_FILE, any);
+        graph.addVertex(relatedFileNode);
+        graph.addEdge(productNode, relatedFileNode);
+
+        ResultDAGConverter.addStringAttribute(graph,
+                relatedFileNode,
+                NsiliConstants.CREATOR,
+                FILE_CREATOR,
+                orb);
+        addTestDateAttribute(graph, relatedFileNode, NsiliConstants.DATE_TIME_DECLARED, orb);
+        ResultDAGConverter.addDoubleAttribute(graph,
+                relatedFileNode,
+                NsiliConstants.EXTENT,
+                FILE_EXTENT,
+                orb);
+        ResultDAGConverter.addStringAttribute(graph,
+                relatedFileNode,
+                NsiliConstants.FILE_TYPE,
+                NsiliConstants.THUMBNAIL_TYPE,
+                orb);
+        ResultDAGConverter.addStringAttribute(graph,
+                relatedFileNode,
+                NsiliConstants.URL,
+                FILE_PRODUCT_URL,
+                orb);
+        ResultDAGConverter.addBooleanAttribute(graph,
+                relatedFileNode,
+                NsiliConstants.IS_FILE_LOCAL,
+                true,
                 orb);
     }
 
@@ -2646,5 +2695,15 @@ public class TestDAGConverter {
         int minute = 05;
         int second = 10;
         return new GregorianCalendar(year, month, dayOfMonth, hourOfDay, minute, second);
+    }
+
+    private void setupMocks() throws Exception {
+        byte[] testReturn = "TEST RETURN".getBytes();
+        Resource mockResource = mock(Resource.class);
+        ResourceResponse mockResponse = mock(ResourceResponse.class);
+        doReturn(Long.valueOf(testReturn.length)).when(mockResource).getSize();
+        doReturn(testReturn).when(mockResource).getByteArray();
+        doReturn(mockResource).when(mockResponse).getResource();
+        doReturn(mockResponse).when(mockResourceReader).retrieveResource(anyObject(), anyMap());
     }
 }

--- a/distribution/sdk/sample-nsili-server/src/main/java/com/connexta/alliance/nsili/mockserver/client/NsiliClient.java
+++ b/distribution/sdk/sample-nsili-server/src/main/java/com/connexta/alliance/nsili/mockserver/client/NsiliClient.java
@@ -124,6 +124,7 @@ import com.connexta.alliance.nsili.common.UID.ProductHelper;
 import com.connexta.alliance.nsili.transformer.DAGConverter;
 
 import ddf.catalog.data.Metacard;
+import ddf.catalog.resource.impl.URLResourceReader;
 
 public class NsiliClient {
 
@@ -860,7 +861,8 @@ public class NsiliClient {
     }
 
     private String getProductID(DAG dag) {
-        Metacard metacard = DAGConverter.convertDAG(dag, false, "");
+        DAGConverter dagConverter = new DAGConverter(new URLResourceReader());
+        Metacard metacard = dagConverter.convertDAG(dag, false, "");
         return metacard.getId();
     }
 


### PR DESCRIPTION
#### What does this PR do?
Updates the NSILI source to get thumbnail bytes when converting DAG to metacards.
Updated the NSILI endpoint to add a newline at the end of the IOR file for NSILI system compatibility.
Changed output charset encoding
#### Who is reviewing it?
@jaymcnallie @bdeining @dcruver 
#### How should this be tested?
Run JUnit test cases
#### Any background context you want to provide?
#### What are the relevant tickets?
https://codice.atlassian.net/browse/CAL-39 
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests